### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Discord Daily Selection Bot
+
+Discord bot that automatically selects a random user each weekday and manages music recommendations. It supports English and Brazilian Portuguese.
+
+## Features
+
+- Slash commands to register users, list participants and manage selections
+- Daily selection at 9 AM (timezone configurable) skipping Brazilian holidays
+- Music utilities to fetch the next unplayed song from a channel
+- Optional multilingual responses (English default, Portuguese-BR available)
+
+## Requirements
+
+- Node.js >= 18
+- Discord bot token and permissions to register slash commands
+
+## Installation
+
+```bash
+npm install
+```
+
+## Configuration
+
+Create an `.env` file with the following variables:
+
+```
+DISCORD_TOKEN=your-bot-token
+GUILD_ID=your-guild-id
+CHANNEL_ID=id-of-channel-for-daily-messages
+MUSIC_CHANNEL_ID=id-of-channel-with-song-requests
+# Optional
+TIMEZONE=America/Sao_Paulo
+BOT_LANGUAGE=en
+```
+
+## Usage
+
+Run locally in development mode:
+
+```bash
+npm run dev
+```
+
+Build and start:
+
+```bash
+npm run build
+npm start
+```
+
+### Commands
+
+- `register <name>` – register a user by name
+- `join` – self-register using your Discord name
+- `remove <name>` – remove a user
+- `list` – display registered, pending and already selected users
+- `select` – manually select a random user
+- `reset` – reset selection list (or restore original list)
+- `next-song` – show the next unplayed song from the request channel
+- `clear-bunnies` – remove bunny reactions added by the bot
+- `readd <name>` – re-add a previously selected user back into the pool
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-zip": "npm run clean && npm run build && npm run generate-zip"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": "",
   "dependencies": {
     "discord.js": "^14.19.3",


### PR DESCRIPTION
## Summary
- add a project README describing setup and usage
- switch package.json license to MIT and add a LICENSE file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e792c8388325a4428404ba59c3ff