### PR TITLE
Add configurable schedule and multi-country holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Discord bot that automatically selects a random user each weekday and manages mu
 ## Features
 
 - Slash commands to register users, list participants and manage selections
-- Daily selection at 9 AM (timezone configurable) skipping Brazilian holidays
+- Daily selection at a configurable time and weekdays
+  (timezone and holiday countries can be set via environment variables)
 - Music utilities to fetch the next unplayed song from a channel
 - Optional multilingual responses (English default, Portuguese-BR available)
 
@@ -32,7 +33,13 @@ MUSIC_CHANNEL_ID=id-of-channel-with-song-requests
 # Optional
 TIMEZONE=America/Sao_Paulo
 BOT_LANGUAGE=en
+DAILY_TIME=09:00
+DAILY_DAYS=1-5
+HOLIDAY_COUNTRIES=BR
 ```
+`DAILY_TIME` uses 24h format `HH:MM` and `DAILY_DAYS` follows cron day-of-week
+syntax (e.g. `1-5` for Monday–Friday). `HOLIDAY_COUNTRIES` is a comma-separated
+list of country codes (currently `BR` and `US` are supported).
 
 ## Usage
 

--- a/src/__tests__/holidays.test.ts
+++ b/src/__tests__/holidays.test.ts
@@ -1,4 +1,9 @@
-import { isHoliday, getBrazilianHolidays, BRAZILIAN_FIXED_HOLIDAYS } from '../holidays';
+import {
+  isHoliday,
+  getBrazilianHolidays,
+  BRAZILIAN_FIXED_HOLIDAYS,
+  getUSHolidays
+} from '../holidays';
 
 describe('Módulo de Feriados', () => {
   describe('Feriados Fixos', () => {
@@ -73,4 +78,23 @@ describe('Módulo de Feriados', () => {
       expect(datasUnicas.size).toBe(datas.length);
     });
   });
-}); 
+
+  describe('Feriados dos EUA', () => {
+    const feriadosUS2024 = getUSHolidays(2024);
+
+    test('deve incluir Thanksgiving em 28/11/2024', () => {
+      const tg = feriadosUS2024.find(h => h.name === 'Thanksgiving');
+      expect(tg?.date).toBe('28/11');
+    });
+
+    test('isHoliday deve reconhecer Independence Day', () => {
+      const date = new Date(2024, 6, 4); // 4 de julho
+      expect(isHoliday(date, ['US'])).toBe(true);
+    });
+
+    test('isHoliday deve considerar múltiplos países', () => {
+      const date = new Date(2024, 0, 1); // 1 de janeiro
+      expect(isHoliday(date, ['BR', 'US'])).toBe(true);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,12 @@ const MUSIC_CHANNEL_ID = process.env.MUSIC_CHANNEL_ID!;
 const USERS_FILE = path.join(__dirname, 'users.json');
 const TIMEZONE = process.env.TIMEZONE ?? 'America/Sao_Paulo';
 const LANGUAGE = process.env.BOT_LANGUAGE ?? 'pt-br';
+const DAILY_TIME = process.env.DAILY_TIME ?? '09:00';
+const DAILY_DAYS = process.env.DAILY_DAYS ?? '1-5';
+const HOLIDAY_COUNTRIES = (process.env.HOLIDAY_COUNTRIES ?? 'BR')
+  .split(',')
+  .map(c => c.trim().toUpperCase())
+  .filter(c => c);
 
 // Set bot language
 i18n.setLanguage(LANGUAGE as 'en' | 'pt-br');
@@ -421,10 +427,12 @@ if (process.env.NODE_ENV !== 'test') {
 
   // =================== Scheduling ===================
   function scheduleDailySelection(): void {
+    const [hour, minute] = DAILY_TIME.split(':').map(n => parseInt(n, 10));
+    const cronExpr = `${minute} ${hour} * * ${DAILY_DAYS}`;
     cron.schedule(
-      '0 9 * * 1-5',
+      cronExpr,
       async () => {
-        if (isHoliday(new Date())) {
+        if (isHoliday(new Date(), HOLIDAY_COUNTRIES)) {
           console.log(i18n.t('daily.holiday'));
           return;
         }


### PR DESCRIPTION
## Summary
- allow setting daily schedule time and days via env vars
- support skipping holidays from US in addition to Brazil
- update README with new options
- cover US holidays in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ea8556b08325ab3a165229116a20