### PR TITLE
Add startup config logging

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,3 +18,17 @@ export const HOLIDAY_COUNTRIES = (process.env.HOLIDAY_COUNTRIES ?? 'BR')
   .split(',')
   .map(c => c.trim().toUpperCase())
   .filter(c => c);
+
+export function logConfig(): void {
+  console.log(
+    '📚 Loaded configuration:',
+    {
+      TIMEZONE,
+      BOT_LANGUAGE: LANGUAGE,
+      DAILY_TIME,
+      DAILY_DAYS,
+      HOLIDAY_COUNTRIES,
+      USERS_FILE
+    }
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ import {
   LANGUAGE,
   DAILY_TIME,
   DAILY_DAYS,
-  HOLIDAY_COUNTRIES
+  HOLIDAY_COUNTRIES,
+  logConfig
 } from './config';
 import {
   UserData,
@@ -46,6 +47,7 @@ import {
 } from './music';
 
 i18n.setLanguage(LANGUAGE as 'en' | 'pt-br');
+logConfig();
 
 const commands = [
   new SlashCommandBuilder()


### PR DESCRIPTION
## Summary
- log configuration on startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847304ca2608325902564428012913d