### PR TITLE
Fix i18n language code handling

### DIFF
--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+const fakePt = JSON.stringify({
+  commands: {
+    list: { name: 'listar', description: '' },
+    register: { name: 'registrar', description: '' }
+  }
+});
+
+const fakeEn = JSON.stringify({
+  commands: {
+    list: { name: 'list', description: '' },
+    register: { name: 'register', description: '' }
+  }
+});
+
+describe('i18n module', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.doMock('fs', () => ({
+      readFileSync: jest.fn((p: string) => {
+        const file = String(p);
+        if (file.includes('pt-br.json')) return fakePt;
+        if (file.includes('en.json')) return fakeEn;
+        return '{}';
+      }),
+      existsSync: jest.fn(),
+      writeFileSync: jest.fn(),
+      promises: { access: jest.fn(), readFile: jest.fn(), writeFile: jest.fn() }
+    }));
+  });
+
+  test('loads Portuguese command names', () => {
+    process.env.NODE_ENV = 'development';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { i18n } = require('../i18n');
+    i18n.setLanguage('pt-br');
+    expect(i18n.getCommandName('list')).toBe('listar');
+    expect(i18n.getCommandName('register')).toBe('registrar');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('🔍 Debug - Loaded translations for pt-br:'),
+      expect.any(String)
+    );
+    consoleSpy.mockRestore();
+  });
+
+  test('logs fallback usage', () => {
+    process.env.NODE_ENV = 'development';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { i18n } = require('../i18n');
+    i18n.setLanguage('pt-br');
+    i18n.t('nonexistent.key');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('🔍 Debug - Fallback used for key')
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,9 +22,13 @@ interface TranslationResource {
 
 const loadTranslations = (lang: Language): TranslationResource => {
   try {
-    return process.env.NODE_ENV === 'test'
-      ? { commands: {} }
-      : JSON.parse(fs.readFileSync(path.join(__dirname, `i18n/${lang}.json`), 'utf-8'));
+    const json = fs.readFileSync(path.join(__dirname, `i18n/${lang}.json`), 'utf-8');
+    const result = JSON.parse(json);
+    console.log(
+      `\u{1F50D} Debug - Loaded translations for ${lang}:`,
+      JSON.stringify(result.commands, null, 2)
+    );
+    return result;
   } catch (error) {
     console.error(`Failed to load translations for ${lang}:`, error);
     return { commands: {} };
@@ -34,6 +38,12 @@ const loadTranslations = (lang: Language): TranslationResource => {
 i18next.init({
   lng: 'en',
   fallbackLng: 'en',
+  // normalize language codes to lowercase so resources like "pt-br" match
+  // environment variables regardless of casing
+  lowerCaseLng: true,
+  // load resources synchronously to ensure translations are available
+  initImmediate: false,
+  saveMissing: true,
   resources: {
     en: {
       translation: loadTranslations('en')
@@ -45,6 +55,10 @@ i18next.init({
   interpolation: {
     escapeValue: false
   }
+});
+
+i18next.on('missingKey', (lngs, ns, key) => {
+  console.log(`\u{1F50D} Debug - Fallback used for key "${key}"`);
 });
 
 export const i18n = {


### PR DESCRIPTION
## Summary
- ensure i18next uses lowercase language codes and loads resources synchronously
- log when translations are loaded and when fallbacks are used
- test that command translations load correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68478e6a8c988325b73d85196843d14f