### PR TITLE
Improve startup logs

### DIFF
--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -37,8 +37,7 @@ describe('i18n module', () => {
     expect(i18n.getCommandName('list')).toBe('listar');
     expect(i18n.getCommandName('register')).toBe('registrar');
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('🔍 Debug - Loaded translations for pt-br:'),
-      expect.any(String)
+      expect.stringContaining('🔍 [pt-br] translations loaded:')
     );
     consoleSpy.mockRestore();
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,14 +21,13 @@ export const HOLIDAY_COUNTRIES = (process.env.HOLIDAY_COUNTRIES ?? 'BR')
 
 export function logConfig(): void {
   console.log(
-    '📚 Loaded configuration:',
-    {
-      TIMEZONE,
-      BOT_LANGUAGE: LANGUAGE,
-      DAILY_TIME,
-      DAILY_DAYS,
-      HOLIDAY_COUNTRIES,
-      USERS_FILE
-    }
+    '📚 Config:',
+    [
+      `TZ=${TIMEZONE}`,
+      `LANG=${LANGUAGE}`,
+      `DAILY=${DAILY_TIME} (${DAILY_DAYS})`,
+      `HOLIDAYS=${HOLIDAY_COUNTRIES.join(',')}`,
+      `USERS=${USERS_FILE}`
+    ].join(' | ')
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -24,10 +24,10 @@ const loadTranslations = (lang: Language): TranslationResource => {
   try {
     const json = fs.readFileSync(path.join(__dirname, `i18n/${lang}.json`), 'utf-8');
     const result = JSON.parse(json);
-    console.log(
-      `\u{1F50D} Debug - Loaded translations for ${lang}:`,
-      JSON.stringify(result.commands, null, 2)
-    );
+    const commands = Object.values(result.commands as Record<string, Command>)
+      .map(c => c.name)
+      .join(', ');
+    console.log(`\u{1F50D} [${lang}] translations loaded: ${commands}`);
     return result;
   } catch (error) {
     console.error(`Failed to load translations for ${lang}:`, error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ function scheduleDailySelection(client: Client): void {
   const [hour, minute] = DAILY_TIME.split(':').map(n => parseInt(n, 10));
   const cronExpr = `${minute} ${hour} * * ${DAILY_DAYS}`;
   console.log(
-    `📅 Scheduling daily selection with expression "${cronExpr}" (timezone: ${TIMEZONE})`
+    `📅 Daily job scheduled at ${DAILY_TIME} (${DAILY_DAYS}) [TZ ${TIMEZONE}]`
   );
   cron.schedule(
     cronExpr,
@@ -160,17 +160,21 @@ if (process.env.NODE_ENV !== 'test') {
   client.once('ready', async () => {
     if (!client.user) throw new Error('Client not properly initialized');
 
-    console.log(`🤖 Bot online as ${client.user.tag}`);
+    console.log(`🤖 Logged in as ${client.user.tag}`);
 
     const users = await loadUsers();
-    console.log('👥 Loaded users:', users.all.map(u => u.name).join(', ') || '(none)');
+    console.log(
+      `👥 Users loaded (${users.all.length}): ${users.all
+        .map(u => u.name)
+        .join(', ') || '(none)'}`
+    );
 
     const rest = new REST({ version: '10' }).setToken(TOKEN);
     await rest.put(Routes.applicationGuildCommands(client.user.id, GUILD_ID), {
       body: commands
     });
 
-    console.log('✅ Commands registered successfully.');
+    console.log('✅ Commands registered');
 
     scheduleDailySelection(client);
   });


### PR DESCRIPTION
## Summary
- shorten translation and config logs
- trim log output when bot starts
- adapt i18n tests to new logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847947beea8832592b9ceb5d36e639f