### PR TITLE
Add test for daily message text

### DIFF
--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -3,14 +3,18 @@ const fakePt = JSON.stringify({
   commands: {
     list: { name: 'listar', description: '' },
     register: { name: 'registrar', description: '' }
-  }
+  },
+  'daily.announcement': 'Usuário do dia: <@{{id}}> ({{name}})',
+  'daily.holiday': 'Feriado'
 });
 
 const fakeEn = JSON.stringify({
   commands: {
     list: { name: 'list', description: '' },
     register: { name: 'register', description: '' }
-  }
+  },
+  'daily.announcement': "Today's user: <@{{id}}> ({{name}})",
+  'daily.holiday': 'Holiday'
 });
 
 describe('i18n module', () => {
@@ -52,5 +56,18 @@ describe('i18n module', () => {
       expect.stringContaining('🔍 Debug - Fallback used for key')
     );
     consoleSpy.mockRestore();
+  });
+
+  test('formats daily announcement message', () => {
+    const { i18n } = require('../i18n');
+    i18n.setLanguage('en');
+    const text = i18n.t('daily.announcement', { id: '42', name: 'Alice' });
+    expect(text).toBe("Today's user: <@42> (Alice)");
+  });
+
+  test('returns holiday message', () => {
+    const { i18n } = require('../i18n');
+    i18n.setLanguage('pt-br');
+    expect(i18n.t('daily.holiday')).toBe('Feriado');
   });
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -13,6 +13,8 @@
   "music.allPlayed": "✅ All recent songs have been played.",
   "selection.readded": "✅ {{name}} has been readded to the selection list.",
   "selection.notSelected": "❌ {{name}} is already in the selection list.",
+  "daily.announcement": "🎉 Today's selected user is <@{{id}}> ({{name}})",
+  "daily.holiday": "🌴 Holiday detected, skipping today's selection.",
   "user.notFound": "❌ User {{name}} not found.",
   "commands": {
     "register": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -13,6 +13,8 @@
   "music.allPlayed": "✅ Todas as músicas recentes já foram tocadas.",
   "selection.readded": "✅ {{name}} foi readicionado(a) à lista de seleção.",
   "selection.notSelected": "❌ {{name}} já está na lista de seleção.",
+  "daily.announcement": "🎉 Usuário selecionado hoje: <@{{id}}> ({{name}})",
+  "daily.holiday": "🌴 Feriado detectado, sem seleção hoje.",
   "selection.resetOriginal": "✅ Lista de seleção foi resetada para o estado original.",
   "selection.resetAll": "✅ {{count}} usuários foram readicionados à lista de seleção.",
   "user.notFound": "❌ Usuário {{name}} não encontrado.",


### PR DESCRIPTION
## Summary
- update i18n tests with daily message strings
- verify daily announcement and holiday translations

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684974e9f3dc83259d0325911a59155c