### PR TITLE
Allow token configuration via setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Create an `.env` file with the following variables:
 
 ```
 DISCORD_TOKEN=your-bot-token
-# The variables below are optional. If omitted, run `/setup` in your server to configure
-# the guild and channel ids.
+# If omitted, run `/setup` in your server to set the token, guild and channel ids.
 GUILD_ID=your-guild-id
 CHANNEL_ID=id-of-channel-for-daily-messages
 MUSIC_CHANNEL_ID=id-of-channel-with-song-requests
@@ -41,6 +40,7 @@ HOLIDAY_COUNTRIES=BR
 USERS_FILE=./src/users.json
 DATE_FORMAT=YYYY-MM-DD
 ```
+
 Set `BOT_LANGUAGE` to `en` or `pt-br` to change the bot responses.
 `DAILY_TIME` uses 24h format `HH:MM` and `DAILY_DAYS` follows cron day-of-week
 syntax (e.g. `1-5` for Monday–Friday). `HOLIDAY_COUNTRIES` is a comma-separated
@@ -66,6 +66,7 @@ To create a production zip with translations and data:
 ```bash
 npm run build-zip
 ```
+
 This archive includes a `serverConfig.json` file used by the `/setup` command to
 store guild and channel information.
 
@@ -82,7 +83,7 @@ store guild and channel information.
 - `readd <name>` – re-add a previously selected user back into the pool
 - `skip-today <name>` – skip today's draw for the specified user
 - `skip-until <name> <date>` – skip selection of a user until the given date (format defined by `DATE_FORMAT`, default `YYYY-MM-DD`)
-- `setup <daily> <music>` – configure the channels if they weren't provided in the `.env`
+- `setup <daily> <music> [token]` – configure the channels and optionally the token if not provided in the `.env`
 
 ## Testing
 

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -1,0 +1,70 @@
+import * as path from 'path';
+
+describe('serverConfig module', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('loadServerConfig returns null when file missing', () => {
+    jest.doMock('fs', () => ({
+      existsSync: jest.fn().mockReturnValue(false),
+      readFileSync: jest.fn(),
+      promises: { writeFile: jest.fn() }
+    }));
+    const { loadServerConfig } = require('../serverConfig');
+    expect(loadServerConfig()).toBeNull();
+  });
+
+  test('loadServerConfig parses existing file', () => {
+    const data = {
+      guildId: '1',
+      channelId: '2',
+      musicChannelId: '3',
+      token: 'abc'
+    };
+    jest.doMock('fs', () => ({
+      existsSync: jest.fn().mockReturnValue(true),
+      readFileSync: jest.fn().mockReturnValue(JSON.stringify(data)),
+      promises: { writeFile: jest.fn() }
+    }));
+    const { loadServerConfig } = require('../serverConfig');
+    expect(loadServerConfig()).toEqual(data);
+  });
+
+  test('saveServerConfig writes config to file', async () => {
+    const writeFile = jest.fn();
+    jest.doMock('fs', () => ({
+      existsSync: jest.fn(),
+      readFileSync: jest.fn(),
+      promises: { writeFile }
+    }));
+    const { saveServerConfig } = require('../serverConfig');
+    const cfg = { guildId: '1', channelId: '2', musicChannelId: '3', token: 't' };
+    await saveServerConfig(cfg);
+    const expectedPath = path.join(path.resolve(__dirname, '..'), 'serverConfig.json');
+    expect(writeFile).toHaveBeenCalledWith(
+      expectedPath,
+      JSON.stringify(cfg, null, 2),
+      'utf-8'
+    );
+  });
+
+  test('updateServerConfig sets exported variables', () => {
+    jest.doMock('fs', () => ({
+      existsSync: jest.fn(),
+      readFileSync: jest.fn(),
+      promises: { writeFile: jest.fn() }
+    }));
+    const config = require('../config');
+    config.updateServerConfig({
+      guildId: 'g',
+      channelId: 'c',
+      musicChannelId: 'm',
+      token: 'tok'
+    });
+    expect(config.GUILD_ID).toBe('g');
+    expect(config.CHANNEL_ID).toBe('c');
+    expect(config.MUSIC_CHANNEL_ID).toBe('m');
+    expect(config.TOKEN).toBe('tok');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,8 @@ import { loadServerConfig, ServerConfig } from './serverConfig';
 
 dotenv.config();
 
-export const TOKEN = process.env.DISCORD_TOKEN!;
-
 const fileConfig = loadServerConfig();
+export let TOKEN = process.env.DISCORD_TOKEN || fileConfig?.token || '';
 
 export let CHANNEL_ID = process.env.CHANNEL_ID || fileConfig?.channelId || '';
 export let GUILD_ID = process.env.GUILD_ID || fileConfig?.guildId || '';
@@ -21,14 +20,15 @@ export const DAILY_TIME = process.env.DAILY_TIME ?? '09:00';
 export const DAILY_DAYS = process.env.DAILY_DAYS ?? '1-5';
 export const HOLIDAY_COUNTRIES = (process.env.HOLIDAY_COUNTRIES ?? 'BR')
   .split(',')
-  .map(c => c.trim().toUpperCase())
-  .filter(c => c);
+  .map((c) => c.trim().toUpperCase())
+  .filter((c) => c);
 export const DATE_FORMAT = process.env.DATE_FORMAT ?? 'YYYY-MM-DD';
 
 export function updateServerConfig(config: ServerConfig): void {
   CHANNEL_ID = config.channelId;
   GUILD_ID = config.guildId;
   MUSIC_CHANNEL_ID = config.musicChannelId;
+  if (config.token) TOKEN = config.token;
 }
 
 export function logConfig(): void {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,7 +4,7 @@ import { ChatInputCommandInteraction } from 'discord.js';
 import { i18n } from './i18n';
 import { UserEntry, UserData, saveUsers, selectUser, formatUsers } from './users';
 import { parseDateString, todayISO } from './date';
-import { DATE_FORMAT, updateServerConfig } from './config';
+import { DATE_FORMAT, updateServerConfig, TOKEN } from './config';
 import { saveServerConfig, ServerConfig } from './serverConfig';
 
 export async function handleRegister(interaction: ChatInputCommandInteraction, data: UserData): Promise<void> {
@@ -136,10 +136,12 @@ export async function handleSetup(interaction: ChatInputCommandInteraction): Pro
   if (!interaction.guildId) return;
   const daily = interaction.options.getChannel('daily', true);
   const music = interaction.options.getChannel('music', true);
+  const token = interaction.options.getString('token') || TOKEN;
   const cfg: ServerConfig = {
     guildId: interaction.guildId,
     channelId: daily.id,
-    musicChannelId: music.id
+    musicChannelId: music.id,
+    token
   };
   await saveServerConfig(cfg);
   updateServerConfig(cfg);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -21,7 +21,7 @@
   "selection.noEligibleUsers": "❌ No eligible users to select.",
   "user.notFound": "❌ User {{name}} not found.",
   "setup.saved": "✅ Configuration saved!",
-  "setup.instructions": "Use /setup to configure channels.",
+  "setup.instructions": "Use /setup to configure channels and token.",
   "commands": {
     "register": {
       "name": "register",
@@ -112,6 +112,10 @@
         "music": {
           "name": "music",
           "description": "Channel for music requests"
+        },
+        "token": {
+          "name": "token",
+          "description": "Bot token (optional)"
         }
       }
     }

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -26,7 +26,7 @@
   "user.selfRegistered": "✅ Você foi registrado(a) com sucesso!",
   "user.removed": "✅ Usuário {{name}} foi removido com sucesso!",
   "setup.saved": "✅ Configuração salva!",
-  "setup.instructions": "Use /configurar para definir os canais.",
+  "setup.instructions": "Use /configurar para definir canais e token.",
   "commands": {
     "register": {
       "name": "registrar",
@@ -117,6 +117,10 @@
         "music": {
           "name": "musica",
           "description": "Canal de pedidos de música"
+        },
+        "token": {
+          "name": "token",
+          "description": "Token do bot (opcional)"
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ i18n.setLanguage(LANGUAGE as 'en' | 'pt-br');
 logConfig();
 
 function scheduleDailySelection(client: Client): void {
-  const [hour, minute] = DAILY_TIME.split(':').map(n => parseInt(n, 10));
+  const [hour, minute] = DAILY_TIME.split(':').map((n) => parseInt(n, 10));
   const cronExpr = `${minute} ${hour} * * ${DAILY_DAYS}`;
   console.log(
     `📅 Daily job scheduled at ${DAILY_TIME} (${DAILY_DAYS}) [TZ ${TIMEZONE}]`
@@ -90,7 +90,7 @@ const commands = [
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('register'))
     .setDescription(i18n.getCommandDescription('register'))
-    .addStringOption(option =>
+    .addStringOption((option) =>
       option
         .setName(i18n.getOptionName('register', 'name'))
         .setDescription(i18n.getOptionDescription('register', 'name'))
@@ -102,7 +102,7 @@ const commands = [
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('remove'))
     .setDescription(i18n.getCommandDescription('remove'))
-    .addStringOption(option =>
+    .addStringOption((option) =>
       option
         .setName(i18n.getOptionName('remove', 'name'))
         .setDescription(i18n.getOptionDescription('remove', 'name'))
@@ -126,7 +126,7 @@ const commands = [
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('readd'))
     .setDescription(i18n.getCommandDescription('readd'))
-    .addStringOption(option =>
+    .addStringOption((option) =>
       option
         .setName(i18n.getOptionName('readd', 'name'))
         .setDescription(i18n.getOptionDescription('readd', 'name'))
@@ -135,7 +135,7 @@ const commands = [
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('skip-today'))
     .setDescription(i18n.getCommandDescription('skip-today'))
-    .addStringOption(option =>
+    .addStringOption((option) =>
       option
         .setName(i18n.getOptionName('skip-today', 'name'))
         .setDescription(i18n.getOptionDescription('skip-today', 'name'))
@@ -144,13 +144,13 @@ const commands = [
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('skip-until'))
     .setDescription(i18n.getCommandDescription('skip-until'))
-    .addStringOption(option =>
+    .addStringOption((option) =>
       option
         .setName(i18n.getOptionName('skip-until', 'name'))
         .setDescription(i18n.getOptionDescription('skip-until', 'name'))
         .setRequired(true)
     )
-    .addStringOption(option =>
+    .addStringOption((option) =>
       option
         .setName(i18n.getOptionName('skip-until', 'date'))
         .setDescription(
@@ -163,19 +163,25 @@ const commands = [
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('setup'))
     .setDescription(i18n.getCommandDescription('setup'))
-    .addChannelOption(option =>
+    .addChannelOption((option) =>
       option
         .setName(i18n.getOptionName('setup', 'daily'))
         .setDescription(i18n.getOptionDescription('setup', 'daily'))
         .setRequired(true)
     )
-    .addChannelOption(option =>
+    .addChannelOption((option) =>
       option
         .setName(i18n.getOptionName('setup', 'music'))
         .setDescription(i18n.getOptionDescription('setup', 'music'))
         .setRequired(true)
     )
-].map(cmd => cmd.toJSON());
+    .addStringOption((option) =>
+      option
+        .setName(i18n.getOptionName('setup', 'token'))
+        .setDescription(i18n.getOptionDescription('setup', 'token'))
+        .setRequired(false)
+    )
+].map((cmd) => cmd.toJSON());
 
 const client = new Client({
   intents: [
@@ -188,23 +194,26 @@ const client = new Client({
 });
 
 if (process.env.NODE_ENV !== 'test') {
-  const commandHandlers: Record<string, (i: ChatInputCommandInteraction, d: UserData) => Promise<void>> = {
+  const commandHandlers: Record<
+    string,
+    (i: ChatInputCommandInteraction, d: UserData) => Promise<void>
+  > = {
     [i18n.getCommandName('register')]: handleRegister,
     [i18n.getCommandName('remove')]: handleRemove,
     [i18n.getCommandName('list')]: handleList,
     [i18n.getCommandName('select')]: handleSelect,
     [i18n.getCommandName('join')]: handleJoin,
     [i18n.getCommandName('reset')]: handleReset,
-    [i18n.getCommandName('next-song')]: async interaction => {
+    [i18n.getCommandName('next-song')]: async (interaction) => {
       await handleNextSong(interaction);
     },
-    [i18n.getCommandName('clear-bunnies')]: async interaction => {
+    [i18n.getCommandName('clear-bunnies')]: async (interaction) => {
       await handleClearReactions(interaction);
     },
     [i18n.getCommandName('readd')]: handleReadd,
     [i18n.getCommandName('skip-today')]: handleSkipToday,
     [i18n.getCommandName('skip-until')]: handleSkipUntil,
-    [i18n.getCommandName('setup')]: async interaction => {
+    [i18n.getCommandName('setup')]: async (interaction) => {
       await handleSetup(interaction);
     }
   };
@@ -216,9 +225,9 @@ if (process.env.NODE_ENV !== 'test') {
 
     const users = await loadUsers();
     console.log(
-      `👥 Users loaded (${users.all.length}): ${users.all
-        .map(u => u.name)
-        .join(', ') || '(none)'}`
+      `👥 Users loaded (${users.all.length}): ${
+        users.all.map((u) => u.name).join(', ') || '(none)'
+      }`
     );
 
     const rest = new REST({ version: '10' }).setToken(TOKEN);
@@ -232,15 +241,15 @@ if (process.env.NODE_ENV !== 'test') {
     scheduleDailySelection(client);
   });
 
-  client.on('guildCreate', guild => {
+  client.on('guildCreate', (guild) => {
     const channel =
-      guild.systemChannel || guild.channels.cache.find(c => c.isTextBased());
+      guild.systemChannel || guild.channels.cache.find((c) => c.isTextBased());
     if (channel && channel.isTextBased()) {
       (channel as TextChannel).send(i18n.t('setup.instructions'));
     }
   });
 
-  client.on('interactionCreate', async interaction => {
+  client.on('interactionCreate', async (interaction) => {
     if (interaction.isChatInputCommand()) {
       console.log(
         `➡️ Command received: /${interaction.commandName} from ${interaction.user.tag}`

--- a/src/serverConfig.sample.json
+++ b/src/serverConfig.sample.json
@@ -1,5 +1,6 @@
 {
   "guildId": "",
   "channelId": "",
-  "musicChannelId": ""
+  "musicChannelId": "",
+  "token": ""
 }

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -5,6 +5,7 @@ export interface ServerConfig {
   guildId: string;
   channelId: string;
   musicChannelId: string;
+  token?: string;
 }
 
 const CONFIG_PATH = path.join(__dirname, 'serverConfig.json');
@@ -20,5 +21,9 @@ export function loadServerConfig(): ServerConfig | null {
 }
 
 export async function saveServerConfig(config: ServerConfig): Promise<void> {
-  await fs.promises.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+  await fs.promises.writeFile(
+    CONFIG_PATH,
+    JSON.stringify(config, null, 2),
+    'utf-8'
+  );
 }


### PR DESCRIPTION
## Summary
- allow providing the bot token in `serverConfig.json`
- update configuration loader to read token from saved config
- extend `/setup` command with optional `token` parameter
- adjust README and translations
- add tests for server configuration logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68498cd84988832586664d7da867db87