### PR TITLE
Fix translation keys

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -119,5 +119,13 @@
         }
       }
     }
-  }
+  },
+  "user.registered": "✅ User {{name}} has been registered!",
+  "user.alreadyRegistered": "❌ User {{name}} is already registered.",
+  "user.selfRegistered": "✅ You have been registered!",
+  "user.alreadySelfRegistered": "❌ You are already registered.",
+  "user.removed": "✅ User {{name}} has been removed!",
+  "selection.nextUser": "➡️ Selected user: <@{{id}}> ({{name}})",
+  "selection.resetOriginal": "✅ Selection list has been reset to original state.",
+  "selection.resetAll": "✅ {{count}} users have been readded to the selection list."
 }

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -124,5 +124,8 @@
         }
       }
     }
-  }
+  },
+  "user.alreadyRegistered": "❌ Usuário {{name}} já está registrado.",
+  "user.alreadySelfRegistered": "❌ Você já está registrado(a).",
+  "selection.nextUser": "➡️ Próximo usuário selecionado: <@{{id}}> ({{name}})"
 }


### PR DESCRIPTION
## Summary
- add missing entries to English and Portuguese translations
- keep newline at end of JSON files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68499435050883258350f2579dfe2476