### PR TITLE
Add export command

### DIFF
--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -5,7 +5,8 @@ import {
   handleList,
   handleSelect,
   handleReset,
-  handleReadd
+  handleReadd,
+  handleExport
 } from '../handlers';
 import type { UserData } from '../users';
 import * as fs from 'fs';
@@ -222,5 +223,22 @@ describe('handlers', () => {
     await handleSetup(interaction);
     expect(saveServerConfig).not.toHaveBeenCalled();
     expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  test('handleExport attaches files when present', async () => {
+    mockFs.existsSync.mockReturnValueOnce(true).mockReturnValueOnce(true);
+    const interaction = createInteraction();
+    await handleExport(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.any(String),
+      files: expect.any(Array)
+    });
+  });
+
+  test('handleExport reports missing files', async () => {
+    mockFs.existsSync.mockReturnValue(false);
+    const interaction = createInteraction();
+    await handleExport(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.any(String));
   });
 });

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -20,7 +20,8 @@ import {
   LANGUAGE,
   DAILY_TIME,
   DAILY_DAYS,
-  HOLIDAY_COUNTRIES
+  HOLIDAY_COUNTRIES,
+  USERS_FILE
 } from './config';
 import {
   saveServerConfig,
@@ -275,4 +276,28 @@ export async function handleSetup(
   await saveServerConfig(cfg);
   updateServerConfig(cfg);
   await interaction.reply(i18n.t('setup.saved'));
+}
+
+export async function handleExport(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const usersPath = USERS_FILE;
+  const configPath = path.join(__dirname, 'serverConfig.json');
+
+  const files: Array<{ attachment: string; name: string }> = [];
+  if (fs.existsSync(usersPath)) {
+    files.push({ attachment: usersPath, name: 'users.json' });
+  }
+  if (fs.existsSync(configPath)) {
+    files.push({ attachment: configPath, name: 'serverConfig.json' });
+  }
+
+  if (files.length === 0) {
+    await interaction.reply(i18n.t('export.noFiles'));
+  } else {
+    await interaction.reply({
+      content: i18n.t('export.success'),
+      files
+    });
+  }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,6 +22,8 @@
   "user.notFound": "❌ User {{name}} not found.",
   "setup.saved": "✅ Configuration saved!",
   "setup.instructions": "Use /setup to configure channels and token.",
+  "export.success": "✅ Attached data files.",
+  "export.noFiles": "❌ No data files found.",
   "commands": {
     "register": {
       "name": "register",
@@ -138,6 +140,10 @@
           "description": "Holiday countries"
         }
       }
+    },
+    "export": {
+      "name": "export",
+      "description": "Export runtime data files"
     }
   },
   "user.registered": "✅ User {{name}} has been registered!",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -27,6 +27,8 @@
   "user.removed": "✅ Usuário {{name}} foi removido com sucesso!",
   "setup.saved": "✅ Configuração salva!",
   "setup.instructions": "Use /configurar para definir canais e token.",
+  "export.success": "✅ Arquivos de dados anexados.",
+  "export.noFiles": "❌ Nenhum arquivo de dados encontrado.",
   "commands": {
     "register": {
       "name": "registrar",
@@ -143,6 +145,10 @@
           "description": "Países de feriado"
         }
       }
+    },
+    "export": {
+      "name": "exportar",
+      "description": "Exporta os arquivos de dados"
     }
   },
   "user.alreadyRegistered": "❌ Usuário {{name}} já está registrado.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ import {
   handleReadd,
   handleSkipToday,
   handleSkipUntil,
-  handleSetup
+  handleSetup,
+  handleExport
 } from './handlers';
 import {
   handleNextSong,
@@ -224,7 +225,10 @@ const commands = [
           { name: 'BR,US', value: 'BR,US' }
         )
         .setRequired(false)
-    )
+    ),
+  new SlashCommandBuilder()
+    .setName(i18n.getCommandName('export'))
+    .setDescription(i18n.getCommandDescription('export'))
 ].map((cmd) => cmd.toJSON());
 
 const client = new Client({
@@ -259,6 +263,9 @@ if (process.env.NODE_ENV !== 'test') {
     [i18n.getCommandName('skip-until')]: handleSkipUntil,
     [i18n.getCommandName('setup')]: async (interaction) => {
       await handleSetup(interaction);
+    },
+    [i18n.getCommandName('export')]: async (interaction) => {
+      await handleExport(interaction);
     }
   };
 
@@ -328,5 +335,6 @@ export {
   handleClearReactions,
   handleSkipToday,
   handleSkipUntil,
-  handleSetup
+  handleSetup,
+  handleExport
 };


### PR DESCRIPTION
## Summary
- add `/export` command for exporting server config and user data
- include translations for EN and PT-BR
- test the new command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a39bc7048325bb7ad0e1e591f80b