### PR TITLE
Handle missing channel IDs in scheduler and music

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -11,6 +11,10 @@ import { i18n } from './i18n';
 import { MUSIC_CHANNEL_ID } from './config';
 
 export async function findNextSong(client: Client): Promise<{ text: string; components?: ActionRowBuilder<ButtonBuilder>[] }> {
+  if (!MUSIC_CHANNEL_ID) {
+    return { text: i18n.t('music.channelError') };
+  }
+
   const requestsChannel = await client.channels.fetch(MUSIC_CHANNEL_ID);
   if (!requestsChannel?.isTextBased()) {
     return { text: i18n.t('music.channelError') };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -35,6 +35,11 @@ export function scheduleDailySelection(client: Client): void {
 
       const { text, components } = await findNextSong(client);
 
+      if (!CHANNEL_ID) {
+        console.error('CHANNEL_ID not configured. Skipping daily announcement');
+        return;
+      }
+
       const channel = await client.channels.fetch(CHANNEL_ID);
       if (channel?.isTextBased()) {
         (channel as TextChannel).send({


### PR DESCRIPTION
## Summary
- avoid 404s when MUSIC_CHANNEL_ID is empty
- skip daily announcement if CHANNEL_ID is not configured

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a8afc3a88325958badd122ec2d5e