### PR TITLE
Add import slash command

### DIFF
--- a/src/__tests__/__mocks__/discord.js.ts
+++ b/src/__tests__/__mocks__/discord.js.ts
@@ -83,6 +83,10 @@ export class MockSlashCommandBuilder {
     return this;
   }
 
+  addAttachmentOption(fn: (option: MockOption) => MockOption) {
+    return this.addStringOption(fn);
+  }
+
   addChannelOption(fn: (option: MockOption) => MockOption) {
     return this.addStringOption(fn);
   }

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -96,6 +96,10 @@ jest.mock('discord.js', () => {
       return this;
     }
 
+    addAttachmentOption(fn: (option: any) => any) {
+      return this.addStringOption(fn);
+    }
+
     addChannelOption(fn: (option: any) => any) {
       return this.addStringOption(fn);
     }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -144,8 +144,24 @@
     "export": {
       "name": "export",
       "description": "Export runtime data files"
+    },
+    "import": {
+      "name": "import",
+      "description": "Import runtime data files",
+      "options": {
+        "users": {
+          "name": "users",
+          "description": "Users JSON file"
+        },
+        "config": {
+          "name": "config",
+          "description": "Server config JSON file"
+        }
+      }
     }
   },
+  "import.success": "✅ Data imported successfully.",
+  "import.invalid": "❌ Invalid or missing files.",
   "user.registered": "✅ User {{name}} has been registered!",
   "user.alreadyRegistered": "❌ User {{name}} is already registered.",
   "user.selfRegistered": "✅ You have been registered!",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -149,8 +149,24 @@
     "export": {
       "name": "exportar",
       "description": "Exporta os arquivos de dados"
+    },
+    "import": {
+      "name": "importar",
+      "description": "Importa os arquivos de dados",
+      "options": {
+        "users": {
+          "name": "usuarios",
+          "description": "Arquivo JSON de usuários"
+        },
+        "config": {
+          "name": "config",
+          "description": "Arquivo JSON de configuração"
+        }
+      }
     }
   },
+  "import.success": "✅ Dados importados com sucesso.",
+  "import.invalid": "❌ Arquivos inválidos ou ausentes.",
   "user.alreadyRegistered": "❌ Usuário {{name}} já está registrado.",
   "user.alreadySelfRegistered": "❌ Você já está registrado(a).",
   "selection.nextUser": "➡️ Próximo usuário selecionado: <@{{id}}> ({{name}})"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ import {
   handleSkipToday,
   handleSkipUntil,
   handleSetup,
-  handleExport
+  handleExport,
+  handleImport
 } from './handlers';
 import {
   handleNextSong,
@@ -189,7 +190,22 @@ const commands = [
     ),
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('export'))
-    .setDescription(i18n.getCommandDescription('export'))
+    .setDescription(i18n.getCommandDescription('export')),
+  new SlashCommandBuilder()
+    .setName(i18n.getCommandName('import'))
+    .setDescription(i18n.getCommandDescription('import'))
+    .addAttachmentOption((option) =>
+      option
+        .setName(i18n.getOptionName('import', 'users'))
+        .setDescription(i18n.getOptionDescription('import', 'users'))
+        .setRequired(false)
+    )
+    .addAttachmentOption((option) =>
+      option
+        .setName(i18n.getOptionName('import', 'config'))
+        .setDescription(i18n.getOptionDescription('import', 'config'))
+        .setRequired(false)
+    )
 ].map((cmd) => cmd.toJSON());
 
 const client = new Client({
@@ -227,6 +243,9 @@ if (process.env.NODE_ENV !== 'test') {
     },
     [i18n.getCommandName('export')]: async (interaction) => {
       await handleExport(interaction);
+    },
+    [i18n.getCommandName('import')]: async (interaction) => {
+      await handleImport(interaction);
     }
   };
 
@@ -298,5 +317,6 @@ export {
   handleSkipUntil,
   handleSetup,
   handleExport,
+  handleImport,
   scheduleDailySelection
 };


### PR DESCRIPTION
## Summary
- create `/import` command to load `users.json` and `serverConfig.json`
- add import messages and command text to English/Portuguese i18n files
- support attachment option in mock SlashCommandBuilder for tests
- implement file download helper using `https`
- test importing configuration and users

## Testing
- `npm test`
- `npm run lint` *(fails: 43 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849a7bb46048325b5a58d39868b5e65