### PR TITLE
Add DATE_FORMAT setup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Set `BOT_LANGUAGE` to `en` or `pt-br` to change the bot responses.
 `DAILY_TIME` uses 24h format `HH:MM` and `DAILY_DAYS` follows cron day-of-week
 syntax (e.g. `1-5` for Monday–Friday). `HOLIDAY_COUNTRIES` is a comma-separated
 list of country codes (currently `BR` and `US` are supported).
+`DATE_FORMAT` controls the date pattern used for the `/skip-until` command and
+can also be changed via `/setup`.
 
 ## Usage
 

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -27,4 +27,16 @@ describe('date utilities', () => {
     expect(todayISO()).toBe('2024-05-20');
     jest.useRealTimers();
   });
+
+  test('isDateFormatValid detects valid patterns', () => {
+    const { isDateFormatValid } = require('../date');
+    expect(isDateFormatValid('YYYY-MM-DD')).toBe(true);
+    expect(isDateFormatValid('DD/MM/YYYY')).toBe(true);
+  });
+
+  test('isDateFormatValid detects invalid patterns', () => {
+    const { isDateFormatValid } = require('../date');
+    expect(isDateFormatValid('YYYY/DD')).toBe(false);
+    expect(isDateFormatValid('ABC')).toBe(false);
+  });
 });

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -168,7 +168,8 @@ describe('handlers', () => {
         language: 'en',
         dailyTime: '09:00',
         dailyDays: '1-5',
-        holidayCountries: ['BR']
+        holidayCountries: ['BR'],
+        dateFormat: 'YYYY-MM-DD'
       })
     }));
     jest.doMock('../config', () => ({
@@ -180,6 +181,7 @@ describe('handlers', () => {
       DAILY_TIME: '09:00',
       DAILY_DAYS: '1-5',
       HOLIDAY_COUNTRIES: ['BR'],
+      DATE_FORMAT: 'YYYY-MM-DD',
       updateServerConfig
     }));
     jest.doMock('../scheduler', () => ({ scheduleDailySelection }));
@@ -208,11 +210,59 @@ describe('handlers', () => {
       language: 'en',
       dailyTime: '09:00',
       dailyDays: '1-5',
-      holidayCountries: ['BR']
+      holidayCountries: ['BR'],
+      dateFormat: 'YYYY-MM-DD'
     });
     expect(updateServerConfig).toHaveBeenCalled();
     expect(scheduleDailySelection).toHaveBeenCalledWith(interaction.client);
     expect(interaction.reply).toHaveBeenCalled();
+  });
+
+  test('handleSetup validates dateFormat', async () => {
+    jest.resetModules();
+    const saveServerConfig = jest.fn();
+    jest.doMock('../serverConfig', () => ({
+      saveServerConfig,
+      loadServerConfig: jest.fn().mockReturnValue({
+        guildId: 'g',
+        channelId: 'c',
+        musicChannelId: 'm',
+        token: 'tok',
+        timezone: 'UTC',
+        language: 'en',
+        dailyTime: '09:00',
+        dailyDays: '1-5',
+        holidayCountries: ['BR'],
+        dateFormat: 'YYYY-MM-DD'
+      })
+    }));
+    const updateServerConfig = jest.fn();
+    jest.doMock('../config', () => ({
+      TOKEN: 'tok',
+      CHANNEL_ID: 'c',
+      MUSIC_CHANNEL_ID: 'm',
+      TIMEZONE: 'UTC',
+      LANGUAGE: 'en',
+      DAILY_TIME: '09:00',
+      DAILY_DAYS: '1-5',
+      HOLIDAY_COUNTRIES: ['BR'],
+      DATE_FORMAT: 'YYYY-MM-DD',
+      updateServerConfig
+    }));
+    jest.doMock('../scheduler', () => ({ scheduleDailySelection: jest.fn() }));
+    const { handleSetup } = await import('../handlers');
+    const interaction = {
+      guildId: 'g',
+      options: {
+        getChannel: jest.fn(),
+        getString: jest.fn((n: string) => (n === 'dateFormat' ? 'bad' : null))
+      },
+      reply: jest.fn(),
+      client: {} as Client
+    } as unknown as ChatInputCommandInteraction;
+    await handleSetup(interaction);
+    expect(saveServerConfig).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith('setup.invalidDateFormat');
   });
 
   test('handleSetup ignores missing guildId', async () => {
@@ -336,7 +386,8 @@ describe('handlers', () => {
       language: 'en',
       dailyTime: '09:00',
       dailyDays: '1-5',
-      holidayCountries: ['BR']
+      holidayCountries: ['BR'],
+      dateFormat: 'YYYY-MM-DD'
     });
     const { handleCheckConfig } = require('../handlers');
     await handleCheckConfig(interaction);
@@ -352,7 +403,8 @@ describe('handlers', () => {
       guildId: '',
       channelId: '',
       musicChannelId: '',
-      token: ''
+      token: '',
+      dateFormat: 'YYYY-MM-DD'
     });
     const { handleCheckConfig } = require('../handlers');
     await handleCheckConfig(interaction);

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -25,7 +25,8 @@ describe('serverConfig module', () => {
       language: 'en',
       dailyTime: '08:00',
       dailyDays: '1-5',
-      holidayCountries: ['BR']
+      holidayCountries: ['BR'],
+      dateFormat: 'YYYY-MM-DD'
     };
     jest.doMock('fs', () => ({
       existsSync: jest.fn().mockReturnValue(true),
@@ -65,7 +66,8 @@ describe('serverConfig module', () => {
       language: 'en',
       dailyTime: '09:00',
       dailyDays: '1-5',
-      holidayCountries: ['BR']
+      holidayCountries: ['BR'],
+      dateFormat: 'YYYY-MM-DD'
     };
     await saveServerConfig(cfg);
     const expectedPath = path.join(
@@ -95,7 +97,8 @@ describe('serverConfig module', () => {
       language: 'en',
       dailyTime: '10:00',
       dailyDays: '1-5',
-      holidayCountries: ['BR', 'US']
+      holidayCountries: ['BR', 'US'],
+      dateFormat: 'YYYY-MM-DD'
     });
     expect(config.GUILD_ID).toBe('g');
     expect(config.CHANNEL_ID).toBe('c');
@@ -106,5 +109,6 @@ describe('serverConfig module', () => {
     expect(config.DAILY_TIME).toBe('10:00');
     expect(config.DAILY_DAYS).toBe('1-5');
     expect(config.HOLIDAY_COUNTRIES).toEqual(['BR', 'US']);
+    expect(config.DATE_FORMAT).toBe('YYYY-MM-DD');
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,8 @@ export let HOLIDAY_COUNTRIES = (
   .split(',')
   .map((c) => c.trim().toUpperCase())
   .filter((c) => c);
-export const DATE_FORMAT = process.env.DATE_FORMAT ?? 'YYYY-MM-DD';
+export let DATE_FORMAT =
+  process.env.DATE_FORMAT || fileConfig?.dateFormat || 'YYYY-MM-DD';
 
 export function updateServerConfig(config: ServerConfig): void {
   CHANNEL_ID = config.channelId;
@@ -41,6 +42,7 @@ export function updateServerConfig(config: ServerConfig): void {
   if (config.dailyTime) DAILY_TIME = config.dailyTime;
   if (config.dailyDays) DAILY_DAYS = config.dailyDays;
   if (config.holidayCountries) HOLIDAY_COUNTRIES = config.holidayCountries;
+  if (config.dateFormat) DATE_FORMAT = config.dateFormat;
 }
 
 export function logConfig(): void {

--- a/src/date.ts
+++ b/src/date.ts
@@ -4,6 +4,28 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+export function isDateFormatValid(format: string): boolean {
+  if (!format.includes('YYYY') || !format.includes('MM') || !format.includes('DD')) {
+    return false;
+  }
+  const pattern =
+    '^' +
+    escapeRegex(format)
+      .replace('YYYY', '(?<year>\\d{4})')
+      .replace('MM', '(?<month>\\d{2})')
+      .replace('DD', '(?<day>\\d{2})') +
+    '$';
+  const sample = format
+    .replace('YYYY', '2024')
+    .replace('MM', '12')
+    .replace('DD', '31');
+  const match = new RegExp(pattern).exec(sample);
+  if (!match || !match.groups) return false;
+  const { year, month, day } = match.groups as Record<string, string>;
+  const iso = `${year}-${month}-${day}`;
+  return !isNaN(Date.parse(iso));
+}
+
 export function parseDateString(input: string): string | null {
   const format = DATE_FORMAT;
   const pattern = '^' +

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,7 +10,7 @@ import {
   selectUser,
   formatUsers
 } from './users';
-import { parseDateString, todayISO } from './date';
+import { parseDateString, todayISO, isDateFormatValid } from './date';
 import {
   DATE_FORMAT,
   updateServerConfig,
@@ -244,7 +244,8 @@ export async function handleSetup(
     language: LANGUAGE,
     dailyTime: DAILY_TIME,
     dailyDays: DAILY_DAYS,
-    holidayCountries: HOLIDAY_COUNTRIES
+    holidayCountries: HOLIDAY_COUNTRIES,
+    dateFormat: DATE_FORMAT
   };
 
   const daily = interaction.options.getChannel(
@@ -273,6 +274,14 @@ export async function handleSetup(
   const holidays = interaction.options.getString(
     i18n.getOptionName('setup', 'holidayCountries')
   );
+  const dateFormat = interaction.options.getString(
+    i18n.getOptionName('setup', 'dateFormat')
+  ) ?? existing.dateFormat;
+
+  if (dateFormat && !isDateFormatValid(dateFormat)) {
+    await interaction.reply(i18n.t('setup.invalidDateFormat'));
+    return;
+  }
 
   const cfg: ServerConfig = {
     guildId: interaction.guildId,
@@ -285,7 +294,8 @@ export async function handleSetup(
     dailyDays,
     holidayCountries: holidays
       ? holidays.split(',').map((c) => c.trim().toUpperCase())
-      : existing.holidayCountries
+      : existing.holidayCountries,
+    dateFormat
   };
 
   await saveServerConfig(cfg);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,6 +22,7 @@
   "user.notFound": "❌ User {{name}} not found.",
   "setup.saved": "✅ Configuration saved!",
   "setup.instructions": "Use /setup to configure channels and token.",
+  "setup.invalidDateFormat": "❌ Invalid date format. Use placeholders YYYY, MM and DD.",
   "export.success": "✅ Attached data files.",
   "export.noFiles": "❌ No data files found.",
   "commands": {
@@ -138,6 +139,10 @@
         "holidayCountries": {
           "name": "holidays",
           "description": "Holiday countries"
+        },
+        "dateFormat": {
+          "name": "dateformat",
+          "description": "Date format (e.g. YYYY-MM-DD)"
         }
       }
     },

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -27,6 +27,7 @@
   "user.removed": "✅ Usuário {{name}} foi removido com sucesso!",
   "setup.saved": "✅ Configuração salva!",
   "setup.instructions": "Use /configurar para definir canais e token.",
+  "setup.invalidDateFormat": "❌ Formato de data inválido. Use YYYY, MM e DD.",
   "export.success": "✅ Arquivos de dados anexados.",
   "export.noFiles": "❌ Nenhum arquivo de dados encontrado.",
   "commands": {
@@ -143,6 +144,10 @@
         "holidayCountries": {
           "name": "feriados",
           "description": "Países de feriado"
+        },
+        "dateFormat": {
+          "name": "formato",
+          "description": "Formato da data (ex.: YYYY-MM-DD)"
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,12 @@ const commands = [
           { name: 'BR,US', value: 'BR,US' }
         )
         .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName(i18n.getOptionName('setup', 'dateFormat'))
+        .setDescription(i18n.getOptionDescription('setup', 'dateFormat'))
+        .setRequired(false)
     ),
   new SlashCommandBuilder()
     .setName(i18n.getCommandName('export'))

--- a/src/serverConfig.sample.json
+++ b/src/serverConfig.sample.json
@@ -7,5 +7,6 @@
   "language": "pt-br",
   "dailyTime": "09:00",
   "dailyDays": "1-5",
-  "holidayCountries": ["BR"]
+  "holidayCountries": ["BR"],
+  "dateFormat": "YYYY-MM-DD"
 }

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -11,6 +11,7 @@ export interface ServerConfig {
   dailyTime?: string;
   dailyDays?: string;
   holidayCountries?: string[];
+  dateFormat?: string;
 }
 
 const CONFIG_PATH = path.join(__dirname, 'serverConfig.json');


### PR DESCRIPTION
## Summary
- allow runtime DATE_FORMAT configuration via `/setup`
- validate date format input
- document new DATE_FORMAT usage
- update translations
- add tests for configuration updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849afbc16948325a0b04abf493b922d