### PR TITLE
Add Portuguese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Discord Daily Selection Bot
+[Leia esta página em Português](README.pt-br.md)
 
 Discord bot that automatically selects a random user each weekday and manages music recommendations. It supports English and Brazilian Portuguese.
 
@@ -7,6 +8,7 @@ Discord bot that automatically selects a random user each weekday and manages mu
 - Slash commands to register users, list participants and manage selections
 - Daily selection at a configurable time and weekdays
   (timezone and holiday countries can be set via environment variables)
+- Slash command names are also available in Portuguese (pt-br)
 - Music utilities to fetch the next unplayed song from a channel
 - Optional multilingual responses (English default, Portuguese-BR available)
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,107 @@
+# Bot de Seleção Diária do Discord
+[Leia esta página em inglês](README.md)
+
+Bot do Discord que seleciona automaticamente um usuário aleatório a cada dia útil e gerencia recomendações musicais. Ele suporta inglês e português brasileiro.
+
+## Recursos
+
+- Comandos de barra para registrar usuários, listar participantes e gerenciar seleções
+- Seleção diária em horário e dias configuráveis (fuso horário e países de feriado podem ser definidos por variáveis de ambiente)
+- Utilidades de música para obter a próxima música não tocada de um canal
+- Respostas multilíngues opcionais (inglês por padrão e português-BR disponível)
+
+## Requisitos
+
+- Node.js >= 18
+- Token do bot do Discord e permissões para registrar comandos de barra
+
+## Instalação
+
+```bash
+npm install
+```
+
+## Configuração
+
+Crie um arquivo `.env` com as seguintes variáveis:
+
+```
+DISCORD_TOKEN=seu-token
+# Caso omitido, execute `/setup` no seu servidor para definir token, guild e canal.
+GUILD_ID=id-da-sua-guild
+CHANNEL_ID=id-do-canal-de-mensagens-diarias
+MUSIC_CHANNEL_ID=id-do-canal-de-pedidos-de-musica
+# Opcional
+TIMEZONE=America/Sao_Paulo
+BOT_LANGUAGE=en
+DAILY_TIME=09:00
+DAILY_DAYS=1-5
+HOLIDAY_COUNTRIES=BR
+USERS_FILE=./src/users.json
+DATE_FORMAT=YYYY-MM-DD
+```
+
+Defina `BOT_LANGUAGE` como `en` ou `pt-br` para alterar as respostas do bot. `DAILY_TIME` usa o formato 24h `HH:MM` e `DAILY_DAYS` segue a sintaxe de dia da semana do cron (ex.: `1-5` para segunda a sexta). `HOLIDAY_COUNTRIES` é uma lista separada por vírgulas de códigos de país (`BR` e `US` são suportados). `DATE_FORMAT` controla o padrão de data usado pelo comando `/skip-until` e também pode ser alterado via `/setup`.
+
+## Uso
+
+Execute localmente em modo de desenvolvimento:
+
+```bash
+npm run dev
+```
+
+### Testes e cobertura
+
+Execute a suíte de testes:
+
+```bash
+npm test
+```
+
+Gere um relatório de cobertura e badge:
+
+```bash
+npm run test:coverage
+```
+
+Construa e inicie:
+
+```bash
+npm run build
+npm start
+```
+
+Para criar um zip de produção com traduções e dados:
+
+```bash
+npm run build-zip
+```
+
+Esse arquivo inclui `serverConfig.json` usado pelo comando `/setup` para armazenar informações de guild e canal.
+
+### Comandos
+
+- `registrar <nome>` – registra um usuário pelo nome
+- `entrar` – auto-registro usando seu nome do Discord
+- `remover <nome>` – remove um usuário
+- `listar` – mostra usuários registrados, pendentes e já selecionados
+- `selecionar` – seleciona manualmente um usuário aleatório
+- `resetar` – reseta a lista de seleção (ou restaura a lista original)
+- `proxima-musica` – mostra a próxima música não tocada do canal de pedidos
+- `limpar-coelhos` – remove reações de coelhinho adicionadas pelo bot
+- `readicionar <nome>` – readiciona um usuário previamente selecionado
+- `pular-hoje <nome>` – pula o sorteio de hoje para o usuário informado
+- `pular-ate <nome> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`)
+- `configurar` – configura canais, horário e outras definições. Informe apenas os parâmetros que deseja atualizar.
+- `verificar-config` – verifica se a configuração do bot está completa.
+
+## Testes
+
+```bash
+npm test
+```
+
+## Licença
+
+Este projeto está licenciado sob a [Licença MIT](LICENSE).


### PR DESCRIPTION
## Summary
- add Portuguese README with English link
- update command list to use translated names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849b362f1848325b3447409ff732671