### PR TITLE
Refresh commands after language change

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,281 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  Client,
+  REST,
+  Routes
+} from 'discord.js';
+import { i18n } from './i18n';
+import {
+  TOKEN,
+  GUILD_ID,
+  DATE_FORMAT
+} from './config';
+import {
+  handleRegister,
+  handleJoin,
+  handleRemove,
+  handleList,
+  handleSelect,
+  handleReset,
+  handleReadd,
+  handleSkipToday,
+  handleSkipUntil,
+  handleSetup,
+  handleExport,
+  handleImport,
+  handleCheckConfig,
+  handleRole
+} from './handlers';
+import {
+  handleNextSong,
+  handleClearReactions
+} from './music';
+import { UserData } from './users';
+
+export function createCommands(): any[] {
+  return [
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('register'))
+      .setDescription(i18n.getCommandDescription('register'))
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('register', 'name'))
+          .setDescription(i18n.getOptionDescription('register', 'name'))
+          .setRequired(true)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('join'))
+      .setDescription(i18n.getCommandDescription('join')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('remove'))
+      .setDescription(i18n.getCommandDescription('remove'))
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('remove', 'name'))
+          .setDescription(i18n.getOptionDescription('remove', 'name'))
+          .setRequired(true)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('list'))
+      .setDescription(i18n.getCommandDescription('list')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('select'))
+      .setDescription(i18n.getCommandDescription('select')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('reset'))
+      .setDescription(i18n.getCommandDescription('reset')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('next-song'))
+      .setDescription(i18n.getCommandDescription('next-song')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('clear-bunnies'))
+      .setDescription(i18n.getCommandDescription('clear-bunnies')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('readd'))
+      .setDescription(i18n.getCommandDescription('readd'))
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('readd', 'name'))
+          .setDescription(i18n.getOptionDescription('readd', 'name'))
+          .setRequired(true)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('skip-today'))
+      .setDescription(i18n.getCommandDescription('skip-today'))
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('skip-today', 'name'))
+          .setDescription(i18n.getOptionDescription('skip-today', 'name'))
+          .setRequired(true)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('skip-until'))
+      .setDescription(i18n.getCommandDescription('skip-until'))
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('skip-until', 'name'))
+          .setDescription(i18n.getOptionDescription('skip-until', 'name'))
+          .setRequired(true)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('skip-until', 'date'))
+          .setDescription(
+            i18n.t('commands.skip-until.options.date.description', {
+              format: DATE_FORMAT
+            })
+          )
+          .setRequired(true)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('setup'))
+      .setDescription(i18n.getCommandDescription('setup'))
+      .addChannelOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'daily'))
+          .setDescription(i18n.getOptionDescription('setup', 'daily'))
+          .setRequired(false)
+      )
+      .addChannelOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'music'))
+          .setDescription(i18n.getOptionDescription('setup', 'music'))
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'token'))
+          .setDescription(i18n.getOptionDescription('setup', 'token'))
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'timezone'))
+          .setDescription(i18n.getOptionDescription('setup', 'timezone'))
+          .addChoices(
+            { name: 'America/Sao_Paulo', value: 'America/Sao_Paulo' },
+            { name: 'America/New_York', value: 'America/New_York' },
+            { name: 'UTC', value: 'UTC' }
+          )
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'language'))
+          .setDescription(i18n.getOptionDescription('setup', 'language'))
+          .addChoices(
+            { name: 'en', value: 'en' },
+            { name: 'pt-br', value: 'pt-br' }
+          )
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'dailyTime'))
+          .setDescription(i18n.getOptionDescription('setup', 'dailyTime'))
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'dailyDays'))
+          .setDescription(i18n.getOptionDescription('setup', 'dailyDays'))
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'holidayCountries'))
+          .setDescription(i18n.getOptionDescription('setup', 'holidayCountries'))
+          .addChoices(
+            { name: 'BR', value: 'BR' },
+            { name: 'US', value: 'US' },
+            { name: 'BR,US', value: 'BR,US' }
+          )
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'dateFormat'))
+          .setDescription(i18n.getOptionDescription('setup', 'dateFormat'))
+          .setRequired(false)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('export'))
+      .setDescription(i18n.getCommandDescription('export')),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('import'))
+      .setDescription(i18n.getCommandDescription('import'))
+      .addAttachmentOption((option) =>
+        option
+          .setName(i18n.getOptionName('import', 'users'))
+          .setDescription(i18n.getOptionDescription('import', 'users'))
+          .setRequired(false)
+      )
+      .addAttachmentOption((option) =>
+        option
+          .setName(i18n.getOptionName('import', 'config'))
+          .setDescription(i18n.getOptionDescription('import', 'config'))
+          .setRequired(false)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('role'))
+      .setDescription(i18n.getCommandDescription('role'))
+      .addUserOption((option) =>
+        option
+          .setName(i18n.getOptionName('role', 'user'))
+          .setDescription(i18n.getOptionDescription('role', 'user'))
+          .setRequired(true)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('role', 'role'))
+          .setDescription(i18n.getOptionDescription('role', 'role'))
+          .addChoices(
+            { name: 'admin', value: 'admin' },
+            { name: 'user', value: 'user' }
+          )
+          .setRequired(true)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('check-config'))
+      .setDescription(i18n.getCommandDescription('check-config'))
+  ].map((cmd) => cmd.toJSON());
+}
+
+export function createAdminCommands(): Set<string> {
+  return new Set([
+    i18n.getCommandName('remove'),
+    i18n.getCommandName('reset'),
+    i18n.getCommandName('readd'),
+    i18n.getCommandName('skip-today'),
+    i18n.getCommandName('skip-until'),
+    i18n.getCommandName('setup'),
+    i18n.getCommandName('export'),
+    i18n.getCommandName('import'),
+    i18n.getCommandName('role')
+  ]);
+}
+
+export function createCommandHandlers(): Record<string, (i: ChatInputCommandInteraction, d: UserData) => Promise<any>> {
+  return {
+    [i18n.getCommandName('register')]: handleRegister,
+    [i18n.getCommandName('remove')]: handleRemove,
+    [i18n.getCommandName('list')]: handleList,
+    [i18n.getCommandName('select')]: handleSelect,
+    [i18n.getCommandName('join')]: handleJoin,
+    [i18n.getCommandName('reset')]: handleReset,
+    [i18n.getCommandName('next-song')]: async (interaction) => {
+      await handleNextSong(interaction);
+    },
+    [i18n.getCommandName('clear-bunnies')]: async (interaction) => {
+      await handleClearReactions(interaction);
+    },
+    [i18n.getCommandName('readd')]: handleReadd,
+    [i18n.getCommandName('skip-today')]: handleSkipToday,
+    [i18n.getCommandName('skip-until')]: handleSkipUntil,
+    [i18n.getCommandName('setup')]: async (interaction) => {
+      return await handleSetup(interaction);
+    },
+    [i18n.getCommandName('export')]: async (interaction) => {
+      await handleExport(interaction);
+    },
+    [i18n.getCommandName('import')]: async (interaction) => {
+      await handleImport(interaction);
+    },
+    [i18n.getCommandName('role')]: async (interaction) => {
+      await handleRole(interaction);
+    },
+    [i18n.getCommandName('check-config')]: async (interaction) => {
+      await handleCheckConfig(interaction);
+    }
+  };
+}
+
+export async function registerCommands(client: Client, commands: any[]): Promise<void> {
+  const rest = new REST({ version: '10' }).setToken(TOKEN);
+  const route = GUILD_ID
+    ? Routes.applicationGuildCommands(client.user!.id, GUILD_ID)
+    : Routes.applicationCommands(client.user!.id);
+  await rest.put(route, { body: commands });
+  console.log('✅ Commands registered');
+}

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -233,8 +233,8 @@ export async function handleSkipUntil(
 
 export async function handleSetup(
   interaction: ChatInputCommandInteraction
-): Promise<void> {
-  if (!interaction.guildId) return;
+): Promise<boolean> {
+  if (!interaction.guildId) return false;
   const existing = loadServerConfig() || {
     guildId: interaction.guildId,
     channelId: CHANNEL_ID,
@@ -280,7 +280,7 @@ export async function handleSetup(
 
   if (dateFormat && !isDateFormatValid(dateFormat)) {
     await interaction.reply(i18n.t('setup.invalidDateFormat'));
-    return;
+    return false;
   }
 
   const cfg: ServerConfig = {
@@ -303,6 +303,7 @@ export async function handleSetup(
   updateServerConfig(cfg);
   scheduleDailySelection(interaction.client);
   await interaction.reply(i18n.t('setup.saved'));
+  return language !== existing.language;
 }
 
 export async function handleExport(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,6 @@
 import {
   Client,
   GatewayIntentBits,
-  REST,
-  Routes,
-  SlashCommandBuilder,
   ChatInputCommandInteraction,
   Partials,
   TextChannel
@@ -13,7 +10,6 @@ import {
   TOKEN,
   GUILD_ID,
   LANGUAGE,
-  DATE_FORMAT,
   logConfig,
   isConfigValid,
   checkRequiredConfig,
@@ -43,6 +39,7 @@ import {
   handleCheckConfig,
   handleRole
 } from './handlers';
+import { createCommands, createAdminCommands, createCommandHandlers, registerCommands } from "./commands";
 import {
   handleNextSong,
   findNextSong,
@@ -54,204 +51,8 @@ import { scheduleDailySelection } from './scheduler';
 i18n.setLanguage(LANGUAGE as 'en' | 'pt-br');
 logConfig();
 
-const commands = [
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('register'))
-    .setDescription(i18n.getCommandDescription('register'))
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('register', 'name'))
-        .setDescription(i18n.getOptionDescription('register', 'name'))
-        .setRequired(true)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('join'))
-    .setDescription(i18n.getCommandDescription('join')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('remove'))
-    .setDescription(i18n.getCommandDescription('remove'))
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('remove', 'name'))
-        .setDescription(i18n.getOptionDescription('remove', 'name'))
-        .setRequired(true)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('list'))
-    .setDescription(i18n.getCommandDescription('list')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('select'))
-    .setDescription(i18n.getCommandDescription('select')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('reset'))
-    .setDescription(i18n.getCommandDescription('reset')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('next-song'))
-    .setDescription(i18n.getCommandDescription('next-song')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('clear-bunnies'))
-    .setDescription(i18n.getCommandDescription('clear-bunnies')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('readd'))
-    .setDescription(i18n.getCommandDescription('readd'))
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('readd', 'name'))
-        .setDescription(i18n.getOptionDescription('readd', 'name'))
-        .setRequired(true)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('skip-today'))
-    .setDescription(i18n.getCommandDescription('skip-today'))
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('skip-today', 'name'))
-        .setDescription(i18n.getOptionDescription('skip-today', 'name'))
-        .setRequired(true)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('skip-until'))
-    .setDescription(i18n.getCommandDescription('skip-until'))
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('skip-until', 'name'))
-        .setDescription(i18n.getOptionDescription('skip-until', 'name'))
-        .setRequired(true)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('skip-until', 'date'))
-        .setDescription(
-          i18n.t('commands.skip-until.options.date.description', {
-            format: DATE_FORMAT
-          })
-        )
-        .setRequired(true)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('setup'))
-    .setDescription(i18n.getCommandDescription('setup'))
-    .addChannelOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'daily'))
-        .setDescription(i18n.getOptionDescription('setup', 'daily'))
-        .setRequired(false)
-    )
-    .addChannelOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'music'))
-        .setDescription(i18n.getOptionDescription('setup', 'music'))
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'token'))
-        .setDescription(i18n.getOptionDescription('setup', 'token'))
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'timezone'))
-        .setDescription(i18n.getOptionDescription('setup', 'timezone'))
-        .addChoices(
-          { name: 'America/Sao_Paulo', value: 'America/Sao_Paulo' },
-          { name: 'America/New_York', value: 'America/New_York' },
-          { name: 'UTC', value: 'UTC' }
-        )
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'language'))
-        .setDescription(i18n.getOptionDescription('setup', 'language'))
-        .addChoices(
-          { name: 'en', value: 'en' },
-          { name: 'pt-br', value: 'pt-br' }
-        )
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'dailyTime'))
-        .setDescription(i18n.getOptionDescription('setup', 'dailyTime'))
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'dailyDays'))
-        .setDescription(i18n.getOptionDescription('setup', 'dailyDays'))
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'holidayCountries'))
-        .setDescription(i18n.getOptionDescription('setup', 'holidayCountries'))
-        .addChoices(
-          { name: 'BR', value: 'BR' },
-          { name: 'US', value: 'US' },
-          { name: 'BR,US', value: 'BR,US' }
-        )
-        .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('setup', 'dateFormat'))
-        .setDescription(i18n.getOptionDescription('setup', 'dateFormat'))
-        .setRequired(false)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('export'))
-    .setDescription(i18n.getCommandDescription('export')),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('import'))
-    .setDescription(i18n.getCommandDescription('import'))
-    .addAttachmentOption((option) =>
-      option
-        .setName(i18n.getOptionName('import', 'users'))
-        .setDescription(i18n.getOptionDescription('import', 'users'))
-        .setRequired(false)
-    )
-    .addAttachmentOption((option) =>
-      option
-        .setName(i18n.getOptionName('import', 'config'))
-        .setDescription(i18n.getOptionDescription('import', 'config'))
-        .setRequired(false)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('role'))
-    .setDescription(i18n.getCommandDescription('role'))
-    .addUserOption((option) =>
-      option
-        .setName(i18n.getOptionName('role', 'user'))
-        .setDescription(i18n.getOptionDescription('role', 'user'))
-        .setRequired(true)
-    )
-    .addStringOption((option) =>
-      option
-        .setName(i18n.getOptionName('role', 'role'))
-        .setDescription(i18n.getOptionDescription('role', 'role'))
-        .addChoices(
-          { name: 'admin', value: 'admin' },
-          { name: 'user', value: 'user' }
-        )
-        .setRequired(true)
-    ),
-  new SlashCommandBuilder()
-    .setName(i18n.getCommandName('check-config'))
-    .setDescription(i18n.getCommandDescription('check-config'))
-].map((cmd) => cmd.toJSON());
-
-const adminCommands = new Set([
-  i18n.getCommandName('remove'),
-  i18n.getCommandName('reset'),
-  i18n.getCommandName('readd'),
-  i18n.getCommandName('skip-today'),
-  i18n.getCommandName('skip-until'),
-  i18n.getCommandName('setup'),
-  i18n.getCommandName('export'),
-  i18n.getCommandName('import'),
-  i18n.getCommandName('role')
-]);
+let commands = createCommands();
+let adminCommands = createAdminCommands();
 
 const client = new Client({
   intents: [
@@ -264,41 +65,7 @@ const client = new Client({
 });
 
 if (process.env.NODE_ENV !== 'test') {
-  const commandHandlers: Record<
-    string,
-    (i: ChatInputCommandInteraction, d: UserData) => Promise<void>
-  > = {
-    [i18n.getCommandName('register')]: handleRegister,
-    [i18n.getCommandName('remove')]: handleRemove,
-    [i18n.getCommandName('list')]: handleList,
-    [i18n.getCommandName('select')]: handleSelect,
-    [i18n.getCommandName('join')]: handleJoin,
-    [i18n.getCommandName('reset')]: handleReset,
-    [i18n.getCommandName('next-song')]: async (interaction) => {
-      await handleNextSong(interaction);
-    },
-    [i18n.getCommandName('clear-bunnies')]: async (interaction) => {
-      await handleClearReactions(interaction);
-    },
-    [i18n.getCommandName('readd')]: handleReadd,
-    [i18n.getCommandName('skip-today')]: handleSkipToday,
-    [i18n.getCommandName('skip-until')]: handleSkipUntil,
-    [i18n.getCommandName('setup')]: async (interaction) => {
-      await handleSetup(interaction);
-    },
-    [i18n.getCommandName('export')]: async (interaction) => {
-      await handleExport(interaction);
-    },
-    [i18n.getCommandName('import')]: async (interaction) => {
-      await handleImport(interaction);
-    },
-    [i18n.getCommandName('role')]: async (interaction) => {
-      await handleRole(interaction);
-    },
-    [i18n.getCommandName('check-config')]: async (interaction) => {
-      await handleCheckConfig(interaction);
-    }
-  };
+  let commandHandlers = createCommandHandlers();
 
   client.once('ready', async () => {
     if (!client.user) throw new Error('Client not properly initialized');
@@ -312,11 +79,7 @@ if (process.env.NODE_ENV !== 'test') {
       }`
     );
 
-    const rest = new REST({ version: '10' }).setToken(TOKEN);
-    const route = GUILD_ID
-      ? Routes.applicationGuildCommands(client.user.id, GUILD_ID)
-      : Routes.applicationCommands(client.user.id);
-    await rest.put(route, { body: commands });
+    await registerCommands(client, commands);
 
     console.log('✅ Commands registered');
 
@@ -357,7 +120,13 @@ if (process.env.NODE_ENV !== 'test') {
       }
       const data = await loadUsers();
       const handler = commandHandlers[interaction.commandName];
-      if (handler) await handler(interaction, data);
+      const result = handler ? await handler(interaction, data) : undefined;
+      if (interaction.commandName === i18n.getCommandName('setup') && result) {
+        commands = createCommands();
+        adminCommands = createAdminCommands();
+        commandHandlers = createCommandHandlers();
+        await registerCommands(client, commands);
+      }
     } else if (interaction.isButton()) {
       await handlePlayButton(interaction);
     }


### PR DESCRIPTION
## Summary
- create dedicated commands module
- support language change in `/setup` by refreshing commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d10dd2e083259ca3d420d3dc55e8