### PR TITLE
Restrict more commands to admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ store guild and channel information.
 
 **User**
 
-- `register <name>` – register a user by name
 - `join` – self-register using your Discord name
 - `list` – display registered, pending and already selected users
 - `select` – manually select a random user
 - `next-song` – show the next unplayed song from the request channel
-- `clear-bunnies` – remove bunny reactions added by the bot
-- `check-config` – verify if the bot configuration is complete.
 
 **Admin**
 
+- `register <name>` – register a user by name
+- `clear-bunnies` – remove bunny reactions added by the bot
+- `check-config` – verify if the bot configuration is complete.
 - `remove <name>` – remove a user
 - `reset` – reset selection list (or restore original list)
 - `readd <name>` – re-add a previously selected user back into the pool
@@ -124,9 +124,10 @@ Discord user does not need to be registered to become an admin.
 
 The initial admin list can be provided using the `ADMIN_IDS` environment variable or the `admins` field in the config file.
 
-Only admins may run configuration commands such as `/setup`, `/import`,
-`/export`, `/skip-*` and `/role` itself. Regular users can still use the basic
-commands like `/register`, `/join`, `/list` and `/select`.
+Only admins may run privileged commands such as `/register`, `/clear-bunnies`,
+`/check-config`, `/setup`, `/import`, `/export`, `/skip-*` and `/role` itself.
+Regular users can still use basic commands like `/join`, `/list`, `/select` and
+`/next-song`.
 
 Use the `/role` command to grant or revoke admin access:
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -82,19 +82,21 @@ Esse arquivo inclui `serverConfig.json` usado pelo comando `/setup` para armazen
 
 ### Comandos
 
-- `registrar <nome>` – registra um usuário pelo nome
+- `registrar <nome>` – registra um usuário pelo nome **(admin)**
 - `entrar` – auto-registro usando seu nome do Discord
 - `remover <nome>` – remove um usuário
 - `listar` – mostra usuários registrados, pendentes e já selecionados
 - `selecionar` – seleciona manualmente um usuário aleatório
 - `resetar` – reseta a lista de seleção (ou restaura a lista original)
 - `proxima-musica` – mostra a próxima música não tocada do canal de pedidos
-- `limpar-coelhos` – remove reações de coelhinho adicionadas pelo bot
+- `limpar-coelhos` – remove reações de coelhinho adicionadas pelo bot **(admin)**
 - `readicionar <nome>` – readiciona um usuário previamente selecionado
 - `pular-hoje <nome>` – pula o sorteio de hoje para o usuário informado
 - `pular-ate <nome> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`)
 - `configurar` – configura canais, horário e outras definições. Informe apenas os parâmetros que deseja atualizar.
-- `verificar-config` – verifica se a configuração do bot está completa.
+- `verificar-config` – verifica se a configuração do bot está completa **(admin)**
+
+Os comandos marcados com **(admin)** só podem ser executados por administradores.
 
 ## Testes
 

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -1,0 +1,20 @@
+import { createAdminCommands } from '../commands';
+
+jest.mock('../i18n', () => ({
+  i18n: {
+    getCommandName: (c: string) => c,
+    getCommandDescription: jest.fn(),
+    getOptionName: jest.fn(),
+    getOptionDescription: jest.fn(),
+    t: jest.fn()
+  }
+}));
+
+describe('createAdminCommands', () => {
+  test('includes restricted commands', () => {
+    const cmds = createAdminCommands();
+    expect(cmds.has('register')).toBe(true);
+    expect(cmds.has('clear-bunnies')).toBe(true);
+    expect(cmds.has('check-config')).toBe(true);
+  });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -232,7 +232,10 @@ export function createAdminCommands(): Set<string> {
     i18n.getCommandName('setup'),
     i18n.getCommandName('export'),
     i18n.getCommandName('import'),
-    i18n.getCommandName('role')
+    i18n.getCommandName('role'),
+    i18n.getCommandName('clear-bunnies'),
+    i18n.getCommandName('check-config'),
+    i18n.getCommandName('register')
   ]);
 }
 


### PR DESCRIPTION
## Summary
- only allow admins to run `clear-bunnies`, `check-config` and `register`
- document new restrictions in README
- include note in pt-br README
- test new admin command list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849dbbad8288325b6770925929ea54c