### PR TITLE
Improve TypeScript typings

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -4,10 +4,10 @@ beforeEach(() => {
 
 test('checkRequiredConfig returns missing fields', async () => {
   const config = await import('../config');
-  config.TOKEN = '' as any;
-  config.GUILD_ID = '' as any;
-  config.CHANNEL_ID = '' as any;
-  config.MUSIC_CHANNEL_ID = '' as any;
+  config.TOKEN = '';
+  config.GUILD_ID = '';
+  config.CHANNEL_ID = '';
+  config.MUSIC_CHANNEL_ID = '';
   expect(config.checkRequiredConfig()).toEqual([
     'TOKEN',
     'GUILD_ID',

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -307,8 +307,8 @@ describe('handlers', () => {
     const updateServerConfig = jest.fn();
     const scheduleDailySelection = jest.fn();
     jest.doMock('https', () => ({
-      get: jest.fn((_url: string, cb: (res: any) => void) => {
-        const res = new EventEmitter();
+      get: jest.fn((_url: string, cb: (res: import('http').IncomingMessage) => void) => {
+        const res = new EventEmitter() as unknown as import('http').IncomingMessage;
         cb(res);
         process.nextTick(() => {
           res.emit('data', Buffer.from('{}'));
@@ -352,8 +352,8 @@ describe('handlers', () => {
     jest.resetModules();
     const EventEmitter = (await import('events')).EventEmitter;
     jest.doMock('https', () => ({
-      get: jest.fn((_url: string, cb: (res: any) => void) => {
-        const res = new EventEmitter();
+      get: jest.fn((_url: string, cb: (res: import('http').IncomingMessage) => void) => {
+        const res = new EventEmitter() as unknown as import('http').IncomingMessage;
         cb(res);
         process.nextTick(() => {
           res.emit('data', Buffer.from('{}'));

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -13,7 +13,7 @@ jest.mock('fs', () => ({
 
 jest.mock('../i18n', () => ({
   i18n: {
-    t: jest.fn((key: string, params: Record<string, any> = {}) => {
+    t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
         'list.empty': '(none)',
         'music.noValidMusic': '✅ No valid music found.',
@@ -51,7 +51,7 @@ jest.mock('fs', () => ({
 // Mock do i18n
 jest.mock('../i18n', () => ({
   i18n: {
-    t: jest.fn((key: string, params: Record<string, any> = {}) => {
+    t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
         'list.empty': '(none)',
         'music.noValidMusic': '✅ No valid music found.',
@@ -173,7 +173,7 @@ describe('Funções Utilitárias', () => {
     });
 
     it('deve manter a estrutura correta dos dados', async () => {
-      let savedData: any;
+      let savedData!: import('../index').UserData;
       (fs.promises.writeFile as jest.Mock).mockImplementation((file, data) => {
         savedData = JSON.parse(data as string);
       });

--- a/src/__tests__/scheduler.test.ts
+++ b/src/__tests__/scheduler.test.ts
@@ -14,9 +14,9 @@ describe('scheduleDailySelection', () => {
 
   test('schedules job and sends message', async () => {
     const cron = await import('node-cron');
-    const mockSchedule = jest.fn((expr, fn) => {
+    const mockSchedule = jest.fn((expr: string, fn: () => void) => {
       fn();
-      return { stop: jest.fn() } as any;
+      return { stop: jest.fn() } as unknown as import('node-cron').ScheduledTask;
     });
     (cron.schedule as jest.Mock).mockImplementation(mockSchedule);
 
@@ -42,9 +42,9 @@ describe('scheduleDailySelection', () => {
 
   test('does nothing when holiday', async () => {
     const cron = await import('node-cron');
-    const mockSchedule = jest.fn((expr, fn) => {
+    const mockSchedule = jest.fn((expr: string, fn: () => void) => {
       fn();
-      return { stop: jest.fn() } as any;
+      return { stop: jest.fn() } as unknown as import('node-cron').ScheduledTask;
     });
     (cron.schedule as jest.Mock).mockImplementation(mockSchedule);
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -13,7 +13,7 @@ jest.mock('fs', () => ({
 
 jest.mock('../i18n', () => ({
   i18n: {
-    t: jest.fn((key: string, params: Record<string, any> = {}) => {
+    t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
         'list.empty': '(none)'
       };
@@ -56,10 +56,20 @@ jest.mock('fs', () => ({
 
 // Mock do discord.js
 jest.mock('discord.js', () => {
+  interface OptionMock {
+    name: string;
+    description: string;
+    required: boolean;
+    setName(name: string): this;
+    setDescription(description: string): this;
+    setRequired(required: boolean): this;
+    addChoices(...choices: unknown[]): this;
+  }
+
   class MockSlashCommandBuilder {
     private name = '';
     private description = '';
-    private readonly options: any[] = [];
+    private readonly options: OptionMock[] = [];
 
     setName(name: string) {
       this.name = name;
@@ -71,8 +81,8 @@ jest.mock('discord.js', () => {
       return this;
     }
 
-    addStringOption(fn: (option: any) => any) {
-      const option = {
+    addStringOption(fn: (option: OptionMock) => OptionMock) {
+      const option: OptionMock = {
         name: '',
         description: '',
         required: false,
@@ -88,7 +98,7 @@ jest.mock('discord.js', () => {
           this.required = required;
           return this;
         },
-        addChoices(..._choices: any[]) {
+        addChoices(..._choices: unknown[]) {
           return this;
         }
       };
@@ -96,15 +106,15 @@ jest.mock('discord.js', () => {
       return this;
     }
 
-    addAttachmentOption(fn: (option: any) => any) {
+    addAttachmentOption(fn: (option: OptionMock) => OptionMock) {
       return this.addStringOption(fn);
     }
 
-    addChannelOption(fn: (option: any) => any) {
+    addChannelOption(fn: (option: OptionMock) => OptionMock) {
       return this.addStringOption(fn);
     }
 
-    addUserOption(fn: (option: any) => any) {
+    addUserOption(fn: (option: OptionMock) => OptionMock) {
       return this.addStringOption(fn);
     }
 
@@ -146,7 +156,7 @@ jest.mock('discord.js', () => {
 // Mock do i18n
 jest.mock('../i18n', () => ({
   i18n: {
-    t: jest.fn((key: string, params: Record<string, any> = {}) => {
+    t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
         'list.empty': '(none)'
       };
@@ -274,7 +284,7 @@ describe('Funções Utilitárias', () => {
     });
 
     it('deve manter a estrutura correta dos dados', async () => {
-      let savedData: any;
+      let savedData!: import('../index').UserData;
       (fs.promises.writeFile as jest.Mock).mockImplementation((file, data) => {
         savedData = JSON.parse(data as string);
       });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,8 @@ import {
   ChatInputCommandInteraction,
   Client,
   REST,
-  Routes
+  Routes,
+  type RESTPostAPIApplicationCommandsJSONBody
 } from 'discord.js';
 import { i18n } from './i18n';
 import {
@@ -33,7 +34,7 @@ import {
 } from './music';
 import { UserData } from './users';
 
-export function createCommands(): any[] {
+export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
   return [
     new SlashCommandBuilder()
       .setName(i18n.getCommandName('register'))
@@ -239,7 +240,12 @@ export function createAdminCommands(): Set<string> {
   ]);
 }
 
-export function createCommandHandlers(): Record<string, (i: ChatInputCommandInteraction, d: UserData) => Promise<any>> {
+export type CommandHandler = (
+  i: ChatInputCommandInteraction,
+  d: UserData
+) => Promise<void | boolean>;
+
+export function createCommandHandlers(): Record<string, CommandHandler> {
   return {
     [i18n.getCommandName('register')]: handleRegister,
     [i18n.getCommandName('remove')]: handleRemove,
@@ -274,7 +280,10 @@ export function createCommandHandlers(): Record<string, (i: ChatInputCommandInte
   };
 }
 
-export async function registerCommands(client: Client, commands: any[]): Promise<void> {
+export async function registerCommands(
+  client: Client,
+  commands: RESTPostAPIApplicationCommandsJSONBody[]
+): Promise<void> {
   const rest = new REST({ version: '10' }).setToken(TOKEN);
   const route = GUILD_ID
     ? Routes.applicationGuildCommands(client.user!.id, GUILD_ID)


### PR DESCRIPTION
## Summary
- improve command creation typing by using `RESTPostAPIApplicationCommandsJSONBody`
- define `CommandHandler` type
- strongly type mocks in tests and remove remaining `any`
- fix scheduler tests to return a typed `ScheduledTask`
- ensure temp variables are typed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849dd1c189483258043137e03a83f62