### PR TITLE
Enable guild config via /setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ store guild and channel information.
 - `readd <name>` – re-add a previously selected user back into the pool
 - `skip-today <name>` – skip today's draw for the specified user
 - `skip-until <name> <date>` – skip selection of a user until the given date (format defined by `DATE_FORMAT`, default `YYYY-MM-DD`)
-- `setup` – configure channels, time and other settings. Provide only the parameters you want to update.
+- `setup` – configure channels, guild ID and other settings. Provide only the parameters you want to update.
 - `export` – export data files
 - `import` – import runtime data files
 - `role <user> <role>` – set a user's role (`admin` or `user`)

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -93,7 +93,7 @@ Esse arquivo inclui `serverConfig.json` usado pelo comando `/setup` para armazen
 - `readicionar <nome>` – readiciona um usuário previamente selecionado
 - `pular-hoje <nome>` – pula o sorteio de hoje para o usuário informado
 - `pular-ate <nome> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`)
-- `configurar` – configura canais, horário e outras definições. Informe apenas os parâmetros que deseja atualizar.
+- `configurar` – configura canais, ID da guild e outras definições. Informe apenas os parâmetros que deseja atualizar.
 - `verificar-config` – verifica se a configuração do bot está completa **(admin)**
 
 Os comandos marcados com **(admin)** só podem ser executados por administradores.

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -195,15 +195,19 @@ describe('handlers', () => {
           .mockReturnValueOnce({ id: 'newDaily' })
           .mockReturnValueOnce(null),
         getString: jest.fn((name: string) =>
-          name === 'timezone' ? 'UTC' : null
+          name === 'timezone'
+            ? 'UTC'
+            : name === 'guild'
+            ? 'newGuild'
+            : null
         )
       },
       reply: jest.fn(),
       client: {} as Client
     } as unknown as ChatInputCommandInteraction;
-    await handleSetup(interaction);
+    const res = await handleSetup(interaction);
     expect(saveServerConfig).toHaveBeenCalledWith({
-      guildId: 'guild',
+      guildId: 'newGuild',
       channelId: 'newDaily',
       musicChannelId: 'music',
       token: 'tok',
@@ -218,6 +222,7 @@ describe('handlers', () => {
     expect(updateServerConfig).toHaveBeenCalled();
     expect(scheduleDailySelection).toHaveBeenCalledWith(interaction.client);
     expect(interaction.reply).toHaveBeenCalled();
+    expect(res).toBe(true);
   });
 
   test('handleSetup validates dateFormat', async () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -132,6 +132,12 @@ export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
       )
       .addStringOption((option) =>
         option
+          .setName(i18n.getOptionName('setup', 'guild'))
+          .setDescription(i18n.getOptionDescription('setup', 'guild'))
+          .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
           .setName(i18n.getOptionName('setup', 'timezone'))
           .setDescription(i18n.getOptionDescription('setup', 'timezone'))
           .addChoices(

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -120,6 +120,10 @@
           "name": "token",
           "description": "Bot token (optional)"
         },
+        "guild": {
+          "name": "guild",
+          "description": "Target guild ID"
+        },
         "timezone": {
           "name": "timezone",
           "description": "Timezone"

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -125,6 +125,10 @@
           "name": "token",
           "description": "Token do bot (opcional)"
         },
+        "guild": {
+          "name": "guild",
+          "description": "ID da guild"
+        },
         "timezone": {
           "name": "timezone",
           "description": "Fuso horário"


### PR DESCRIPTION
## Summary
- allow specifying guild ID in the setup command
- reapply commands when guild or language changes
- document new `guild` option
- test setup with guild change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e5921c5c83259e5a33ebb06bb831