### PR TITLE
Implement configurable Jockie Music command

### DIFF
--- a/src/__tests__/__mocks__/discord.js.ts
+++ b/src/__tests__/__mocks__/discord.js.ts
@@ -83,6 +83,10 @@ export class MockSlashCommandBuilder {
     return this;
   }
 
+  addBooleanOption(fn: (option: MockOption) => MockOption) {
+    return this.addStringOption(fn);
+  }
+
   addAttachmentOption(fn: (option: MockOption) => MockOption) {
     return this.addStringOption(fn);
   }

--- a/src/__tests__/__mocks__/discord.js.ts
+++ b/src/__tests__/__mocks__/discord.js.ts
@@ -134,7 +134,8 @@ export const mockChannel = {
   isTextBased: () => true,
   messages: {
     fetch: jest.fn()
-  }
+  },
+  send: jest.fn()
 };
 
 export const GatewayIntentBits = {

--- a/src/__tests__/__mocks__/i18n.ts
+++ b/src/__tests__/__mocks__/i18n.ts
@@ -7,7 +7,8 @@ export const i18n = {
     const translations: Record<string, string> = {
       'list.empty': '(none)',
       'music.noValidMusic': '✅ No valid music found.',
-      'music.marked': '✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n/play {{link}}\n```',
+      'music.marked': '✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n{{command}} {{link}}\n```',
+      'music.markedAuto': '✅ Song marked as played!\n\n🎵 Sent `{{command}} {{link}}` to Jockie Music.',
       'music.reactionsCleared': '✅ Removed {{count}} 🐰 reactions made by the bot.',
       'user.registered': '✅ User {{name}} has been registered!',
       'user.selfRegistered': '✅ You have been registered!',

--- a/src/__tests__/index.runtime.test.ts
+++ b/src/__tests__/index.runtime.test.ts
@@ -36,6 +36,7 @@ jest.mock('discord.js', () => {
     addChannelOption(fn: (o: Option) => unknown) { fn(new Option()); return this; }
     addAttachmentOption(fn: (o: Option) => unknown) { fn(new Option()); return this; }
     addUserOption(fn: (o: Option) => unknown) { fn(new Option()); return this; }
+    addBooleanOption(fn: (o: Option) => unknown) { fn(new Option()); return this; }
     toJSON() { return {}; }
   }
   return {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -18,7 +18,9 @@ jest.mock('../i18n', () => ({
         'list.empty': '(none)',
         'music.noValidMusic': '✅ No valid music found.',
         'music.marked':
-          '✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n/play {{link}}\n```',
+          '✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n{{command}} {{link}}\n```',
+        'music.markedAuto':
+          '✅ Song marked as played!\n\n🎵 Sent `{{command}} {{link}}` to Jockie Music.',
         'music.reactionsCleared': '✅ Removed {{count}} 🐰 reactions made by the bot.'
       };
 
@@ -55,7 +57,8 @@ jest.mock('../i18n', () => ({
       const translations: Record<string, string> = {
         'list.empty': '(none)',
         'music.noValidMusic': '✅ No valid music found.',
-        'music.marked': '✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n/play {{link}}\n```',
+        'music.marked': '✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n{{command}} {{link}}\n```',
+        'music.markedAuto': '✅ Song marked as played!\n\n🎵 Sent `{{command}} {{link}}` to Jockie Music.',
         'music.reactionsCleared': '✅ Removed {{count}} 🐰 reactions made by the bot.'
       };
 

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -27,7 +27,9 @@ describe('serverConfig module', () => {
       dailyDays: '1-5',
       holidayCountries: ['BR'],
       dateFormat: 'YYYY-MM-DD',
-      admins: ['a']
+      admins: ['a'],
+      sendPlayCommand: false,
+      playCommand: '/play'
     };
     jest.doMock('fs', () => ({
       existsSync: jest.fn().mockReturnValue(true),
@@ -69,7 +71,9 @@ describe('serverConfig module', () => {
       dailyDays: '1-5',
       holidayCountries: ['BR'],
       dateFormat: 'YYYY-MM-DD',
-      admins: []
+      admins: [],
+      sendPlayCommand: false,
+      playCommand: '/play'
     };
     await saveServerConfig(cfg);
     const expectedPath = path.join(
@@ -101,7 +105,9 @@ describe('serverConfig module', () => {
       dailyDays: '1-5',
       holidayCountries: ['BR', 'US'],
       dateFormat: 'YYYY-MM-DD',
-      admins: ['x']
+      admins: ['x'],
+      sendPlayCommand: false,
+      playCommand: '/play'
     });
     expect(config.GUILD_ID).toBe('g');
     expect(config.CHANNEL_ID).toBe('c');
@@ -114,5 +120,7 @@ describe('serverConfig module', () => {
     expect(config.HOLIDAY_COUNTRIES).toEqual(['BR', 'US']);
     expect(config.DATE_FORMAT).toBe('YYYY-MM-DD');
     expect(config.ADMINS).toEqual(['x']);
+    expect(config.SEND_PLAY_COMMAND).toBe(false);
+    expect(config.PLAY_COMMAND).toBe('/play');
   });
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -106,6 +106,10 @@ jest.mock('discord.js', () => {
       return this;
     }
 
+    addBooleanOption(fn: (option: OptionMock) => OptionMock) {
+      return this.addStringOption(fn);
+    }
+
     addAttachmentOption(fn: (option: OptionMock) => OptionMock) {
       return this.addStringOption(fn);
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -193,6 +193,14 @@ export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
             i18n.getOptionDescription('setup', 'sendPlayCommand')
           )
           .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'playCommand'))
+          .setDescription(
+            i18n.getOptionDescription('setup', 'playCommand')
+          )
+          .setRequired(false)
       ),
     new SlashCommandBuilder()
       .setName(i18n.getCommandName('export'))

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -185,6 +185,14 @@ export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
           .setName(i18n.getOptionName('setup', 'dateFormat'))
           .setDescription(i18n.getOptionDescription('setup', 'dateFormat'))
           .setRequired(false)
+      )
+      .addBooleanOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'sendPlayCommand'))
+          .setDescription(
+            i18n.getOptionDescription('setup', 'sendPlayCommand')
+          )
+          .setRequired(false)
       ),
     new SlashCommandBuilder()
       .setName(i18n.getCommandName('export'))

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,11 @@ export let CHANNEL_ID = process.env.CHANNEL_ID || fileConfig?.channelId || '';
 export let GUILD_ID = process.env.GUILD_ID || fileConfig?.guildId || '';
 export let MUSIC_CHANNEL_ID =
   process.env.MUSIC_CHANNEL_ID || fileConfig?.musicChannelId || '';
+export let PLAY_COMMAND =
+  process.env.PLAY_COMMAND || fileConfig?.playCommand || '/play';
+export let SEND_PLAY_COMMAND = process.env.SEND_PLAY_COMMAND
+  ? process.env.SEND_PLAY_COMMAND === 'true'
+  : (fileConfig?.sendPlayCommand ?? false);
 export const USERS_FILE = process.env.USERS_FILE
   ? path.resolve(process.env.USERS_FILE)
   : path.join(__dirname, 'users.json');
@@ -57,6 +62,9 @@ export function updateServerConfig(config: ServerConfig): void {
   if (config.holidayCountries) HOLIDAY_COUNTRIES = config.holidayCountries;
   if (config.dateFormat) DATE_FORMAT = config.dateFormat;
   if (config.admins && !envAdmins) ADMINS = config.admins;
+  if (config.sendPlayCommand !== undefined)
+    SEND_PLAY_COMMAND = config.sendPlayCommand;
+  if (config.playCommand) PLAY_COMMAND = config.playCommand;
 }
 
 export function logConfig(): void {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -288,6 +288,9 @@ export async function handleSetup(
   const sendPlayCommand = interaction.options.getBoolean(
     i18n.getOptionName('setup', 'sendPlayCommand')
   );
+  const playCommand =
+    interaction.options.getString(i18n.getOptionName('setup', 'playCommand')) ??
+    existing.playCommand;
 
   const guildId = guildIdOption ?? interaction.guildId ?? existing.guildId;
 
@@ -311,7 +314,7 @@ export async function handleSetup(
     dateFormat,
     admins: existing.admins,
     sendPlayCommand: sendPlayCommand ?? existing.sendPlayCommand,
-    playCommand: existing.playCommand
+    playCommand
   };
 
   await saveServerConfig(cfg);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -23,7 +23,9 @@ import {
   DAILY_DAYS,
   HOLIDAY_COUNTRIES,
   USERS_FILE,
-  checkRequiredConfig
+  checkRequiredConfig,
+  PLAY_COMMAND,
+  SEND_PLAY_COMMAND
 } from './config';
 import { scheduleDailySelection } from './scheduler';
 import {
@@ -249,7 +251,9 @@ export async function handleSetup(
     dailyTime: DAILY_TIME,
     dailyDays: DAILY_DAYS,
     holidayCountries: HOLIDAY_COUNTRIES,
-    dateFormat: DATE_FORMAT
+    dateFormat: DATE_FORMAT,
+    sendPlayCommand: SEND_PLAY_COMMAND,
+    playCommand: PLAY_COMMAND
   };
 
   const daily = interaction.options.getChannel(
@@ -278,9 +282,12 @@ export async function handleSetup(
   const holidays = interaction.options.getString(
     i18n.getOptionName('setup', 'holidayCountries')
   );
-  const dateFormat = interaction.options.getString(
-    i18n.getOptionName('setup', 'dateFormat')
-  ) ?? existing.dateFormat;
+  const dateFormat =
+    interaction.options.getString(i18n.getOptionName('setup', 'dateFormat')) ??
+    existing.dateFormat;
+  const sendPlayCommand = interaction.options.getBoolean(
+    i18n.getOptionName('setup', 'sendPlayCommand')
+  );
 
   const guildId = guildIdOption ?? interaction.guildId ?? existing.guildId;
 
@@ -302,7 +309,9 @@ export async function handleSetup(
       ? holidays.split(',').map((c) => c.trim().toUpperCase())
       : existing.holidayCountries,
     dateFormat,
-    admins: existing.admins
+    admins: existing.admins,
+    sendPlayCommand: sendPlayCommand ?? existing.sendPlayCommand,
+    playCommand: existing.playCommand
   };
 
   await saveServerConfig(cfg);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,7 +4,8 @@
   "list.pending": "**Pending selection:**\n{{users}}",
   "list.selected": "**Already selected:**\n{{users}}",
   "music.noValidMusic": "✅ No valid music found.",
-  "music.marked": "✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n/play {{link}}\n```",
+  "music.marked": "✅ Song marked as played!\n\n🎵 To play the song in the bot, copy and send the command below:\n```\n{{command}} {{link}}\n```",
+  "music.markedAuto": "✅ Song marked as played!\n\n🎵 Sent `{{command}} {{link}}` to Jockie Music.",
   "music.reactionsCleared": "✅ Removed {{count}} 🐰 reactions made by the bot.",
   "music.channelError": "Could not access the music channel.",
   "music.processError": "Error processing the music.",
@@ -147,6 +148,10 @@
         "dateFormat": {
           "name": "dateformat",
           "description": "Date format (e.g. YYYY-MM-DD)"
+        },
+        "sendPlayCommand": {
+          "name": "sendcommand",
+          "description": "Send play command to Jockie"
         }
       }
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -152,6 +152,10 @@
         "sendPlayCommand": {
           "name": "sendcommand",
           "description": "Send play command to Jockie"
+        },
+        "playCommand": {
+          "name": "playcommand",
+          "description": "Play command to send"
         }
       }
     },

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -155,8 +155,12 @@
           "description": "Formato da data (ex.: YYYY-MM-DD)"
         },
         "sendPlayCommand": {
-          "name": "enviarcomando",
+          "name": "habilitar-comando-play",
           "description": "Enviar comando de play para o Jockie"
+        },
+        "playCommand": {
+          "name": "comando-play",
+          "description": "Comando de play a ser enviado"
         }
       }
     },

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -4,7 +4,8 @@
   "list.pending": "**Aguardando seleção:**\n{{users}}",
   "list.selected": "**Já selecionados:**\n{{users}}",
   "music.noValidMusic": "✅ Nenhuma música válida encontrada.",
-  "music.marked": "✅ Música marcada como tocada!\n\n🎵 Para tocar a música no bot, copie e envie o comando abaixo:\n```\n/play {{link}}\n```",
+  "music.marked": "✅ Música marcada como tocada!\n\n🎵 Para tocar a música no bot, copie e envie o comando abaixo:\n```\n{{command}} {{link}}\n```",
+  "music.markedAuto": "✅ Música marcada como tocada!\n\n🎵 Comando `{{command}} {{link}}` enviado para o Jockie Music.",
   "music.reactionsCleared": "✅ Removidas {{count}} reações 🐰 feitas pelo bot.",
   "music.channelError": "Não foi possível acessar o canal de música.",
   "music.processError": "Erro ao processar a música.",
@@ -152,6 +153,10 @@
         "dateFormat": {
           "name": "formato",
           "description": "Formato da data (ex.: YYYY-MM-DD)"
+        },
+        "sendPlayCommand": {
+          "name": "enviarcomando",
+          "description": "Enviar comando de play para o Jockie"
         }
       }
     },

--- a/src/serverConfig.sample.json
+++ b/src/serverConfig.sample.json
@@ -9,5 +9,7 @@
   "dailyDays": "1-5",
   "holidayCountries": ["BR"],
   "dateFormat": "YYYY-MM-DD",
+  "sendPlayCommand": false,
+  "playCommand": "/play",
   "admins": []
 }

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -13,6 +13,8 @@ export interface ServerConfig {
   holidayCountries?: string[];
   dateFormat?: string;
   admins?: string[];
+  sendPlayCommand?: boolean;
+  playCommand?: string;
 }
 
 const CONFIG_PATH = path.join(__dirname, 'serverConfig.json');


### PR DESCRIPTION
## Summary
- rename `autoPlay` option to `sendPlayCommand`
- update play button logic to respect new flag
- revise setup options and translations
- adjust tests and sample config

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849edcafa6483259b5bcff0b1598ac1