### PR TITLE
Implement voice channel for play button

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ DISCORD_TOKEN=your-bot-token
 GUILD_ID=your-guild-id
 CHANNEL_ID=id-of-channel-for-daily-messages
 MUSIC_CHANNEL_ID=id-of-channel-with-song-requests
+DAILY_VOICE_CHANNEL_ID=id-of-voice-channel-to-play-songs
 # Optional
 TIMEZONE=America/Sao_Paulo
 BOT_LANGUAGE=en

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -32,6 +32,7 @@ DISCORD_TOKEN=seu-token
 GUILD_ID=id-da-sua-guild
 CHANNEL_ID=id-do-canal-de-mensagens-diarias
 MUSIC_CHANNEL_ID=id-do-canal-de-pedidos-de-musica
+DAILY_VOICE_CHANNEL_ID=id-do-canal-de-voz-para-tocar-musicas
 # Opcional
 TIMEZONE=America/Sao_Paulo
 BOT_LANGUAGE=en

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -164,6 +164,7 @@ describe('handlers', () => {
         guildId: 'guild',
         channelId: 'old',
         musicChannelId: 'music',
+        dailyVoiceChannelId: 'voice',
         token: 'tok',
         timezone: 'America/Sao_Paulo',
         language: 'en',
@@ -180,6 +181,7 @@ describe('handlers', () => {
       TOKEN: 'tok',
       CHANNEL_ID: 'old',
       MUSIC_CHANNEL_ID: 'music',
+      DAILY_VOICE_CHANNEL_ID: 'voice',
       TIMEZONE: 'America/Sao_Paulo',
       LANGUAGE: 'en',
       DAILY_TIME: '09:00',
@@ -198,6 +200,7 @@ describe('handlers', () => {
         getChannel: jest
           .fn()
           .mockReturnValueOnce({ id: 'newDaily' })
+          .mockReturnValueOnce(null)
           .mockReturnValueOnce(null),
         getString: jest.fn((name: string) =>
           name === 'timezone' ? 'UTC' : name === 'guild' ? 'newGuild' : null
@@ -212,6 +215,7 @@ describe('handlers', () => {
       guildId: 'newGuild',
       channelId: 'newDaily',
       musicChannelId: 'music',
+      dailyVoiceChannelId: 'voice',
       token: 'tok',
       timezone: 'UTC',
       language: 'en',
@@ -240,6 +244,7 @@ describe('handlers', () => {
         guildId: 'guild',
         channelId: 'old',
         musicChannelId: 'music',
+        dailyVoiceChannelId: 'voice',
         token: 'tok',
         timezone: 'America/Sao_Paulo',
         language: 'en',
@@ -256,6 +261,7 @@ describe('handlers', () => {
       TOKEN: 'tok',
       CHANNEL_ID: 'old',
       MUSIC_CHANNEL_ID: 'music',
+      DAILY_VOICE_CHANNEL_ID: 'voice',
       TIMEZONE: 'America/Sao_Paulo',
       LANGUAGE: 'en',
       DAILY_TIME: '09:00',
@@ -271,7 +277,11 @@ describe('handlers', () => {
     const interaction = {
       guildId: 'guild',
       options: {
-        getChannel: jest.fn().mockReturnValueOnce(null).mockReturnValueOnce(null),
+        getChannel: jest
+          .fn()
+          .mockReturnValueOnce(null)
+          .mockReturnValueOnce(null)
+          .mockReturnValueOnce(null),
         getString: jest.fn((name: string) =>
           name === 'playCommand' ? '!play' : null
         ),
@@ -298,6 +308,7 @@ describe('handlers', () => {
         guildId: 'g',
         channelId: 'c',
         musicChannelId: 'm',
+        dailyVoiceChannelId: 'v',
         token: 'tok',
         timezone: 'UTC',
         language: 'en',
@@ -314,6 +325,7 @@ describe('handlers', () => {
       TOKEN: 'tok',
       CHANNEL_ID: 'c',
       MUSIC_CHANNEL_ID: 'm',
+      DAILY_VOICE_CHANNEL_ID: 'v',
       TIMEZONE: 'UTC',
       LANGUAGE: 'en',
       DAILY_TIME: '09:00',
@@ -471,6 +483,7 @@ describe('handlers', () => {
       guildId: 'g',
       channelId: 'c',
       musicChannelId: 'm',
+      dailyVoiceChannelId: 'v',
       token: 't',
       timezone: 'UTC',
       language: 'en',
@@ -493,6 +506,7 @@ describe('handlers', () => {
       guildId: '',
       channelId: '',
       musicChannelId: '',
+      dailyVoiceChannelId: '',
       token: '',
       dateFormat: 'YYYY-MM-DD'
     });

--- a/src/__tests__/music.test.ts
+++ b/src/__tests__/music.test.ts
@@ -132,6 +132,7 @@ describe('Comandos de Música', () => {
   let mockButtonInteraction: MockButtonInteraction;
   let mockClientInstance: Client<true>;
   let mockChannelInstance: MockChannel;
+  let mockVoiceChannelInstance: MockChannel;
   let mockMessageInstance: MockMessage;
   let originalConsoleError: typeof console.error;
 
@@ -144,6 +145,7 @@ describe('Comandos de Música', () => {
     const config = await import('../config');
     config.MUSIC_CHANNEL_ID = 'requests';
     config.SEND_PLAY_COMMAND = true;
+    config.DAILY_VOICE_CHANNEL_ID = 'dailyVoice';
 
     mockClientInstance = {
       intents: [
@@ -167,6 +169,14 @@ describe('Comandos de Música', () => {
       },
       send: jest.fn()
     };
+  mockVoiceChannelInstance = {
+    ...mockChannel,
+    isTextBased: function (this: MockChannel): this is TextChannel {
+      return true;
+    },
+    messages: { fetch: jest.fn() },
+    send: jest.fn()
+  };
 
     mockMessageInstance = {
       ...mockMessageTemplate,
@@ -205,7 +215,11 @@ describe('Comandos de Música', () => {
 
     (
       mockClientInstance.channels as unknown as MockChannelManager
-    ).fetch.mockResolvedValue(mockChannelInstance);
+    ).fetch.mockImplementation((id: string) => {
+      if (id === 'requests') return Promise.resolve(mockChannelInstance);
+      if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+      return Promise.resolve(null);
+    });
   });
 
   afterEach(() => {
@@ -250,7 +264,11 @@ describe('Comandos de Música', () => {
     it('deve encontrar a próxima música não marcada', async () => {
       (
         mockClientInstance.channels as unknown as MockChannelManager
-      ).fetch.mockResolvedValue(mockChannelInstance);
+      ).fetch.mockImplementation((id: string) => {
+        if (id === 'requests') return Promise.resolve(mockChannelInstance);
+        if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+        return Promise.resolve(null);
+      });
       mockChannelInstance.messages.fetch.mockResolvedValue(
         new MockCollection([['123', mockMessageInstance]])
       );
@@ -273,7 +291,11 @@ describe('Comandos de Música', () => {
       });
       (
         mockClientInstance.channels as unknown as MockChannelManager
-      ).fetch.mockResolvedValue(mockChannelInstance);
+      ).fetch.mockImplementation((id: string) => {
+        if (id === 'requests') return Promise.resolve(mockChannelInstance);
+        if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+        return Promise.resolve(null);
+      });
       mockChannelInstance.messages.fetch.mockResolvedValue(
         new MockCollection([['123', mockMessageInstance]])
       );
@@ -293,7 +315,11 @@ describe('Comandos de Música', () => {
     it('deve marcar a música como tocada', async () => {
       (
         mockClientInstance.channels as unknown as MockChannelManager
-      ).fetch.mockResolvedValue(mockChannelInstance);
+      ).fetch.mockImplementation((id: string) => {
+        if (id === 'requests') return Promise.resolve(mockChannelInstance);
+        if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+        return Promise.resolve(null);
+      });
       mockChannelInstance.messages.fetch.mockResolvedValue(mockMessageInstance);
 
       await handlePlayButton(
@@ -301,7 +327,7 @@ describe('Comandos de Música', () => {
       );
 
       expect(mockMessageInstance.react).toHaveBeenCalledWith('🐰');
-      expect(mockChannelInstance.send).toHaveBeenCalledWith(
+      expect(mockVoiceChannelInstance.send).toHaveBeenCalledWith(
         '/play https://example.com/song'
       );
       expect(mockButtonInteraction.reply).toHaveBeenCalledWith({
@@ -314,7 +340,11 @@ describe('Comandos de Música', () => {
     it('deve lidar com erro ao processar a música', async () => {
       (
         mockClientInstance.channels as unknown as MockChannelManager
-      ).fetch.mockResolvedValue(mockChannelInstance);
+      ).fetch.mockImplementation((id: string) => {
+        if (id === 'requests') return Promise.resolve(mockChannelInstance);
+        if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+        return Promise.resolve(null);
+      });
       mockChannelInstance.messages.fetch.mockRejectedValue(
         new Error('Test error')
       );
@@ -341,7 +371,11 @@ describe('Comandos de Música', () => {
 
       (
         mockClientInstance.channels as unknown as MockChannelManager
-      ).fetch.mockResolvedValue(mockChannelInstance);
+      ).fetch.mockImplementation((id: string) => {
+        if (id === 'requests') return Promise.resolve(mockChannelInstance);
+        if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+        return Promise.resolve(null);
+      });
       mockChannelInstance.messages.fetch.mockResolvedValue(messageWithLink);
 
       await handlePlayButton(
@@ -353,7 +387,7 @@ describe('Comandos de Música', () => {
         components: expect.any(Array),
         flags: 1 << 6
       });
-      expect(mockChannelInstance.send).toHaveBeenCalledWith(
+      expect(mockVoiceChannelInstance.send).toHaveBeenCalledWith(
         '/play https://example.com/song.mp3'
       );
     });
@@ -376,7 +410,11 @@ describe('Comandos de Música', () => {
 
       (
         mockClientInstance.channels as unknown as MockChannelManager
-      ).fetch.mockResolvedValue(mockChannelInstance);
+      ).fetch.mockImplementation((id: string) => {
+        if (id === 'requests') return Promise.resolve(mockChannelInstance);
+        if (id === 'dailyVoice') return Promise.resolve(mockVoiceChannelInstance);
+        return Promise.resolve(null);
+      });
       mockChannelInstance.messages.fetch.mockResolvedValue(
         new MockCollection([['123', messageWithReaction]])
       );

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -20,6 +20,7 @@ describe('serverConfig module', () => {
       guildId: '1',
       channelId: '2',
       musicChannelId: '3',
+      dailyVoiceChannelId: '4',
       token: 'abc',
       timezone: 'UTC',
       language: 'en',
@@ -64,6 +65,7 @@ describe('serverConfig module', () => {
       guildId: '1',
       channelId: '2',
       musicChannelId: '3',
+      dailyVoiceChannelId: '4',
       token: 't',
       timezone: 'UTC',
       language: 'en',
@@ -98,6 +100,7 @@ describe('serverConfig module', () => {
       guildId: 'g',
       channelId: 'c',
       musicChannelId: 'm',
+      dailyVoiceChannelId: 'v',
       token: 'tok',
       timezone: 'UTC',
       language: 'en',
@@ -112,6 +115,7 @@ describe('serverConfig module', () => {
     expect(config.GUILD_ID).toBe('g');
     expect(config.CHANNEL_ID).toBe('c');
     expect(config.MUSIC_CHANNEL_ID).toBe('m');
+    expect(config.DAILY_VOICE_CHANNEL_ID).toBe('v');
     expect(config.TOKEN).toBe('tok');
     expect(config.TIMEZONE).toBe('UTC');
     expect(config.LANGUAGE).toBe('en');

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,6 +124,12 @@ export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
           .setDescription(i18n.getOptionDescription('setup', 'music'))
           .setRequired(false)
       )
+      .addChannelOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'voice'))
+          .setDescription(i18n.getOptionDescription('setup', 'voice'))
+          .setRequired(false)
+      )
       .addStringOption((option) =>
         option
           .setName(i18n.getOptionName('setup', 'token'))

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,8 @@ export let CHANNEL_ID = process.env.CHANNEL_ID || fileConfig?.channelId || '';
 export let GUILD_ID = process.env.GUILD_ID || fileConfig?.guildId || '';
 export let MUSIC_CHANNEL_ID =
   process.env.MUSIC_CHANNEL_ID || fileConfig?.musicChannelId || '';
+export let DAILY_VOICE_CHANNEL_ID =
+  process.env.DAILY_VOICE_CHANNEL_ID || fileConfig?.dailyVoiceChannelId || '';
 export let PLAY_COMMAND =
   process.env.PLAY_COMMAND || fileConfig?.playCommand || '/play';
 export let SEND_PLAY_COMMAND = process.env.SEND_PLAY_COMMAND
@@ -54,6 +56,8 @@ export function updateServerConfig(config: ServerConfig): void {
   CHANNEL_ID = config.channelId;
   GUILD_ID = config.guildId;
   MUSIC_CHANNEL_ID = config.musicChannelId;
+  if (config.dailyVoiceChannelId)
+    DAILY_VOICE_CHANNEL_ID = config.dailyVoiceChannelId;
   if (config.token) TOKEN = config.token;
   if (config.timezone) TIMEZONE = config.timezone;
   if (config.language) LANGUAGE = config.language;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -25,7 +25,8 @@ import {
   USERS_FILE,
   checkRequiredConfig,
   PLAY_COMMAND,
-  SEND_PLAY_COMMAND
+  SEND_PLAY_COMMAND,
+  DAILY_VOICE_CHANNEL_ID
 } from './config';
 import { scheduleDailySelection } from './scheduler';
 import {
@@ -245,6 +246,7 @@ export async function handleSetup(
     guildId: guildIdOption ?? interaction.guildId!,
     channelId: CHANNEL_ID,
     musicChannelId: MUSIC_CHANNEL_ID,
+    dailyVoiceChannelId: DAILY_VOICE_CHANNEL_ID,
     token: TOKEN,
     timezone: TIMEZONE,
     language: LANGUAGE,
@@ -252,6 +254,7 @@ export async function handleSetup(
     dailyDays: DAILY_DAYS,
     holidayCountries: HOLIDAY_COUNTRIES,
     dateFormat: DATE_FORMAT,
+    admins: [],
     sendPlayCommand: SEND_PLAY_COMMAND,
     playCommand: PLAY_COMMAND
   };
@@ -262,6 +265,10 @@ export async function handleSetup(
   );
   const music = interaction.options.getChannel(
     i18n.getOptionName('setup', 'music'),
+    false
+  );
+  const voice = interaction.options.getChannel(
+    i18n.getOptionName('setup', 'voice'),
     false
   );
   const token =
@@ -303,6 +310,7 @@ export async function handleSetup(
     guildId,
     channelId: daily?.id ?? existing.channelId,
     musicChannelId: music?.id ?? existing.musicChannelId,
+    dailyVoiceChannelId: voice?.id ?? existing.dailyVoiceChannelId,
     token,
     timezone,
     language,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -117,6 +117,10 @@
           "name": "music",
           "description": "Channel for music requests"
         },
+        "voice": {
+          "name": "voice",
+          "description": "Voice channel for playing music"
+        },
         "token": {
           "name": "token",
           "description": "Bot token (optional)"

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -122,6 +122,10 @@
           "name": "musicas",
           "description": "Canal de pedidos de música"
         },
+        "voice": {
+          "name": "voz",
+          "description": "Canal de voz para tocar a música"
+        },
         "token": {
           "name": "token",
           "description": "Token do bot (opcional)"

--- a/src/music.ts
+++ b/src/music.ts
@@ -8,7 +8,12 @@ import {
   TextChannel
 } from 'discord.js';
 import { i18n } from './i18n';
-import { MUSIC_CHANNEL_ID, PLAY_COMMAND, SEND_PLAY_COMMAND } from './config';
+import {
+  MUSIC_CHANNEL_ID,
+  DAILY_VOICE_CHANNEL_ID,
+  PLAY_COMMAND,
+  SEND_PLAY_COMMAND
+} from './config';
 
 export async function findNextSong(
   client: Client
@@ -119,6 +124,9 @@ export async function handlePlayButton(
 
   const originalMessageId = customId.replace('play_', '');
   const channel = await interaction.client.channels.fetch(MUSIC_CHANNEL_ID);
+  const voice = DAILY_VOICE_CHANNEL_ID
+    ? await interaction.client.channels.fetch(DAILY_VOICE_CHANNEL_ID)
+    : null;
 
   if (!channel?.isTextBased()) {
     await interaction.reply({
@@ -157,7 +165,9 @@ export async function handlePlayButton(
 
     await originalMsg.react('🐰');
     if (SEND_PLAY_COMMAND) {
-      await (channel as TextChannel).send(`${PLAY_COMMAND} ${linkToPlay}`);
+      const target =
+        voice && voice.isTextBased() ? (voice as TextChannel) : (channel as TextChannel);
+      await target.send(`${PLAY_COMMAND} ${linkToPlay}`);
     }
 
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/src/serverConfig.sample.json
+++ b/src/serverConfig.sample.json
@@ -2,6 +2,7 @@
   "guildId": "",
   "channelId": "",
   "musicChannelId": "",
+  "dailyVoiceChannelId": "",
   "token": "",
   "timezone": "America/Sao_Paulo",
   "language": "pt-br",

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -5,6 +5,7 @@ export interface ServerConfig {
   guildId: string;
   channelId: string;
   musicChannelId: string;
+  dailyVoiceChannelId?: string;
   token?: string;
   timezone?: string;
   language?: string;


### PR DESCRIPTION
## Summary
- allow configuring a voice channel for autoplay
- update play button logic to use the configured voice channel
- expose dailyVoiceChannelId via config and setup command
- document new variable in READMEs
- adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849fedaca1c8325bbf6c870edfc1e1b