### PR TITLE
feat: add voice config check and improve playback

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -8,11 +8,13 @@ test('checkRequiredConfig returns missing fields', async () => {
   config.GUILD_ID = '';
   config.CHANNEL_ID = '';
   config.MUSIC_CHANNEL_ID = '';
+  config.DAILY_VOICE_CHANNEL_ID = '';
   expect(config.checkRequiredConfig()).toEqual([
     'TOKEN',
     'GUILD_ID',
     'CHANNEL_ID',
-    'MUSIC_CHANNEL_ID'
+    'MUSIC_CHANNEL_ID',
+    'DAILY_VOICE_CHANNEL_ID'
   ]);
 });
 
@@ -22,6 +24,7 @@ test('isConfigValid returns true when all fields set', async () => {
   config.GUILD_ID = 'g';
   config.CHANNEL_ID = 'c';
   config.MUSIC_CHANNEL_ID = 'm';
+  config.DAILY_VOICE_CHANNEL_ID = 'd';
   expect(config.isConfigValid()).toBe(true);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
   logConfig,
   isConfigValid,
   checkRequiredConfig,
-  canUseAdminCommands
+  canUseAdminCommands,
+  watchServerConfig
 } from './config';
 import {
   UserData,
@@ -48,6 +49,17 @@ import { scheduleDailySelection } from './scheduler';
 
 i18n.setLanguage(LANGUAGE as 'en' | 'pt-br');
 logConfig();
+
+const missingCfg = checkRequiredConfig();
+if (missingCfg.length === 0) {
+  console.log('✅ Required configuration present');
+} else {
+  console.warn(`⚠️ Missing configuration: ${missingCfg.join(', ')}`);
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  watchServerConfig();
+}
 
 let commands = createCommands();
 let adminCommands = createAdminCommands();


### PR DESCRIPTION
## Summary
- warn when voice channel config missing
- show voice channel in config logs
- refine playback handling and add error logs
- update config tests for new required field

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head -n 20`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684a1d7a80f88325b30467c72ea2cc40