### PR TITLE
Add Discord permission integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ Discord bot that automatically selects a random user each weekday and manages mu
 - Node.js >= 18
 - Discord bot token and permissions to register slash commands
 
+## Discord setup
+
+Invite the bot with the `bot` and `applications.commands` scopes and grant these
+permissions:
+
+- Send Messages
+- Read Message History
+- Add Reactions
+- Manage Messages (needed for `/clear-bunnies`)
+- Embed Links
+- Attach Files
+- Connect and Speak in voice channels
+- Use Application Commands
+
+This set of permissions corresponds to the integer `3270720`.
+Enable the **Message Content Intent** in the Discord developer portal and ensure
+the bot role can view and interact in the channels defined by
+`CHANNEL_ID`, `MUSIC_CHANNEL_ID` and `DAILY_VOICE_CHANNEL_ID`.
+
 ## Installation
 
 ```bash

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -16,6 +16,24 @@ Bot do Discord que seleciona automaticamente um usuário aleatório a cada dia �
 - Node.js >= 18
 - Token do bot do Discord e permissões para registrar comandos slash (/comando)
 
+## Configuração no Discord
+
+Convide o bot usando os escopos `bot` e `applications.commands` e garanta as
+seguintes permissões:
+
+- Enviar mensagens
+- Ler histórico de mensagens
+- Adicionar reações
+- Gerenciar mensagens (necessário para `/limpar-coelhos`)
+- Inserir links e anexos
+- Conectar e falar em canais de voz
+- Usar comandos de aplicação
+
+Esse conjunto de permissões corresponde ao inteiro `3270720`.
+Ative também a **Message Content Intent** no portal de desenvolvedores do
+Discord e certifique-se de que o papel do bot possa visualizar e interagir nos
+canais definidos por `CHANNEL_ID`, `MUSIC_CHANNEL_ID` e `DAILY_VOICE_CHANNEL_ID`.
+
 ## Instalação
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify required Discord bot permissions
- note integer value for the permission set in both English and Portuguese READMEs

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684a22bfbd1c8325a0dd319824a20212