### PR TITLE
Fix EMFILE error when watching config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,1 +1,8 @@
-module.exports = require('./.eslintrc.json');
+const { FlatCompat } = require('@eslint/eslintrc');
+const js = require('@eslint/js');
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
+});
+module.exports = compat.config(require('./.eslintrc.json'));

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -49,3 +49,24 @@ test('ADMINS loaded from environment variable', async () => {
   expect(cfg.ADMINS).toEqual(['a', 'b']);
   delete process.env.ADMIN_IDS;
 });
+
+test('reloadServerConfig updates values from file', async () => {
+  jest.doMock('fs', () => ({
+    existsSync: jest.fn().mockReturnValue(true),
+    readFileSync: jest
+      .fn()
+      .mockReturnValue(
+        JSON.stringify({
+          guildId: 'g1',
+          channelId: 'c1',
+          musicChannelId: 'm1'
+        })
+      ),
+    promises: { writeFile: jest.fn() }
+  }));
+  const cfg = await import('../config');
+  cfg.reloadServerConfig();
+  expect(cfg.GUILD_ID).toBe('g1');
+  expect(cfg.CHANNEL_ID).toBe('c1');
+  expect(cfg.MUSIC_CHANNEL_ID).toBe('m1');
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,8 @@
 import * as path from 'path';
-import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import { loadServerConfig, ServerConfig } from './serverConfig';
 import RBAC from '@rbac/rbac';
 
-const CONFIG_PATH = path.join(__dirname, 'serverConfig.json');
-const ROOT_CONFIG_PATH = path.resolve(__dirname, '..', 'serverConfig.json');
 
 dotenv.config();
 
@@ -109,23 +106,14 @@ export async function canUseAdminCommands(id: string): Promise<boolean> {
   return rbac.can(getRole(id), 'admin');
 }
 
-export function watchServerConfig(): void {
-  const pathToUse = fs.existsSync(CONFIG_PATH)
-    ? CONFIG_PATH
-    : fs.existsSync(ROOT_CONFIG_PATH)
-    ? ROOT_CONFIG_PATH
-    : null;
-
-  if (!pathToUse) return;
-
-  fs.watch(pathToUse, (eventType) => {
-    if (eventType === 'change') {
-      const cfg = loadServerConfig();
-      if (cfg) {
-        console.log('🔄 serverConfig.json changed, reloading');
-        updateServerConfig(cfg);
-        logConfig();
-      }
-    }
-  });
+/**
+ * Reload configuration from `serverConfig.json` if present.
+ * This is used instead of file watchers and should be called
+ * before handling commands that depend on the config.
+ */
+export function reloadServerConfig(): void {
+  const cfg = loadServerConfig();
+  if (cfg) {
+    updateServerConfig(cfg);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   isConfigValid,
   checkRequiredConfig,
   canUseAdminCommands,
-  watchServerConfig
+  reloadServerConfig
 } from './config';
 import {
   UserData,
@@ -57,9 +57,6 @@ if (missingCfg.length === 0) {
   console.warn(`⚠️ Missing configuration: ${missingCfg.join(', ')}`);
 }
 
-if (process.env.NODE_ENV !== 'test') {
-  watchServerConfig();
-}
 
 let commands = createCommands();
 let adminCommands = createAdminCommands();
@@ -107,6 +104,7 @@ if (process.env.NODE_ENV !== 'test') {
 
   client.on('interactionCreate', async (interaction) => {
     if (interaction.isChatInputCommand()) {
+      reloadServerConfig();
       console.log(
         `➡️ Command received: /${interaction.commandName} from ${interaction.user.tag}`
       );


### PR DESCRIPTION
## Summary
- handle config reload reactively, remove file watchers
- add test for `reloadServerConfig`
- restore ESLint config for compatibility

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684a271e2e3483259d0c143c5d0e8cbc