### PR TITLE
Add YT cookie setup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ YOUTUBE_COOKIE=your-youtube-cookie
 
 `ADMIN_IDS` should list the Discord user IDs that start with admin rights. You can also
 edit `serverConfig.json` (either inside `src/` or at the repository root) to manage the list.
-`YOUTUBE_COOKIE` may be required for videos that ask you to sign in to confirm you're not a bot. If playback fails, the bot automatically falls back to `ytdl-core`.
+`YOUTUBE_COOKIE` may be required for videos that ask you to sign in to confirm you're not a bot. If playback fails, the bot automatically falls back to `ytdl-core`. You can set this value in the `.env` file or later using `/setup` with the `cookie` option.
 
 Set `BOT_LANGUAGE` to `en` or `pt-br` to change the bot responses.
 `DAILY_TIME` uses 24h format `HH:MM` and `DAILY_DAYS` follows cron day-of-week

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -63,7 +63,7 @@ DATE_FORMAT=YYYY-MM-DD
 YOUTUBE_COOKIE=seu-cookie-do-youtube
 ```
 `ADMIN_IDS` deve listar os IDs dos usuários do Discord que iniciam com direitos de administrador. Você também pode editar `serverConfig.json` para gerenciar a lista.
-`YOUTUBE_COOKIE` pode ser necessário para vídeos que exibem "Sign in to confirm you're not a bot". Caso a reprodução falhe, o bot tenta usar `ytdl-core` automaticamente.
+`YOUTUBE_COOKIE` pode ser necessário para vídeos que exibem "Sign in to confirm you're not a bot". Caso a reprodução falhe, o bot tenta usar `ytdl-core` automaticamente. Você pode definir esse valor no `.env` ou mais tarde através do `/configurar` usando a opção `cookie`.
 
 Defina `BOT_LANGUAGE` como `en` ou `pt-br` para alterar as respostas do bot. `DAILY_TIME` usa o formato 24h `HH:MM` e `DAILY_DAYS` segue a sintaxe de dia da semana do cron (ex.: `1-5` para segunda a sexta). `HOLIDAY_COUNTRIES` é uma lista separada por vírgulas de códigos de país (`BR` e `US` são suportados). `DATE_FORMAT` controla o padrão de data usado pelo comando `/skip-until` e também pode ser alterado via `/setup`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "ffmpeg-static": "^5.1.0",
         "i18next": "^25.2.1",
         "node-cron": "^4.1.0",
-        "play-dl": "^1.8.0",
+        "play-dl": "^1.9.7",
         "ytdl-core": "^4.11.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ffmpeg-static": "^5.1.0",
     "i18next": "^25.2.1",
     "node-cron": "^4.1.0",
-    "play-dl": "^1.8.0",
+    "play-dl": "^1.9.7",
     "ytdl-core": "^4.11.5"
   },
   "devDependencies": {

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -200,9 +200,12 @@ describe('handlers', () => {
           .mockReturnValueOnce({ id: 'newDaily' })
           .mockReturnValueOnce(null)
           .mockReturnValueOnce(null),
-        getString: jest.fn((name: string) =>
-          name === 'timezone' ? 'UTC' : name === 'guild' ? 'newGuild' : null
-        ),
+        getString: jest.fn((name: string) => {
+          if (name === 'timezone') return 'UTC';
+          if (name === 'guild') return 'newGuild';
+          if (name === 'cookie') return 'newCookie';
+          return null;
+        }),
         getBoolean: jest.fn()
       },
       reply: jest.fn(),
@@ -214,7 +217,7 @@ describe('handlers', () => {
       channelId: 'newDaily',
       musicChannelId: 'music',
       dailyVoiceChannelId: 'voice',
-      youtubeCookie: 'cookie',
+      youtubeCookie: 'newCookie',
       token: 'tok',
       timezone: 'UTC',
       language: 'en',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -195,6 +195,12 @@ export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
           .setName(i18n.getOptionName('setup', 'dateFormat'))
           .setDescription(i18n.getOptionDescription('setup', 'dateFormat'))
           .setRequired(false)
+      )
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('setup', 'cookie'))
+          .setDescription(i18n.getOptionDescription('setup', 'cookie'))
+          .setRequired(false)
       ),
     new SlashCommandBuilder()
       .setName(i18n.getCommandName('export'))

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -290,6 +290,9 @@ export async function handleSetup(
   const dateFormat =
     interaction.options.getString(i18n.getOptionName('setup', 'dateFormat')) ??
     existing.dateFormat;
+  const youtubeCookie =
+    interaction.options.getString(i18n.getOptionName('setup', 'cookie')) ??
+    existing.youtubeCookie;
 
   const guildId = guildIdOption ?? interaction.guildId ?? existing.guildId;
 
@@ -313,7 +316,7 @@ export async function handleSetup(
       : existing.holidayCountries,
     dateFormat,
     admins: existing.admins,
-    youtubeCookie: existing.youtubeCookie
+    youtubeCookie
   };
 
   await saveServerConfig(cfg);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -23,7 +23,7 @@
   "selection.noEligibleUsers": "❌ No eligible users to select.",
   "user.notFound": "❌ User {{name}} not found.",
   "setup.saved": "✅ Configuration saved!",
-  "setup.instructions": "Use /setup to configure channels and token.",
+  "setup.instructions": "Use /setup to configure channels, token and cookie.",
   "setup.invalidDateFormat": "❌ Invalid date format. Use placeholders YYYY, MM and DD.",
   "export.success": "✅ Attached data files.",
   "export.noFiles": "❌ No data files found.",
@@ -157,6 +157,10 @@
         "dateFormat": {
           "name": "dateformat",
           "description": "Date format (e.g. YYYY-MM-DD)"
+        },
+        "cookie": {
+          "name": "cookie",
+          "description": "YouTube cookie"
         }
       }
     },

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -28,7 +28,7 @@
   "user.selfRegistered": "✅ Você foi registrado(a) com sucesso!",
   "user.removed": "✅ Usuário {{name}} foi removido com sucesso!",
   "setup.saved": "✅ Configuração salva!",
-  "setup.instructions": "Use /configurar para definir canais e token.",
+  "setup.instructions": "Use /configurar para definir canais, token e cookie.",
   "setup.invalidDateFormat": "❌ Formato de data inválido. Use YYYY, MM e DD.",
   "export.success": "✅ Arquivos de dados anexados.",
   "export.noFiles": "❌ Nenhum arquivo de dados encontrado.",
@@ -162,6 +162,10 @@
         "dateFormat": {
           "name": "formato",
           "description": "Formato da data (ex.: YYYY-MM-DD)"
+        },
+        "cookie": {
+          "name": "cookie",
+          "description": "Cookie do YouTube"
         }
       }
     },


### PR DESCRIPTION
## Summary
- update play-dl to latest version
- allow `/setup` (`/configurar`) to accept a `cookie` parameter
- document how to set YouTube cookie via command
- update Portuguese and English translations
- adjust tests for cookie option

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684a2e6508c88325bee29fc06edfcba0