### PR TITLE
Configure ffmpeg-static path

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -17,6 +17,7 @@ import {
   StreamType
 } from '@discordjs/voice';
 import play from 'play-dl';
+import ffmpegPath from 'ffmpeg-static';
 import ytdl from 'ytdl-core';
 import { Readable } from 'stream';
 import { i18n } from './i18n';
@@ -28,6 +29,13 @@ import {
 
 if (YOUTUBE_COOKIE) {
   play.setToken({ youtube: { cookie: YOUTUBE_COOKIE } });
+}
+// Explicitly configure the bundled ffmpeg path when available
+const playAny = play as unknown as { setFFmpegPath?: (path: string) => void };
+if (typeof playAny.setFFmpegPath === 'function') {
+  playAny.setFFmpegPath(ffmpegPath!);
+} else {
+  process.env.FFMPEG_PATH = ffmpegPath || '';
 }
 
 export async function findNextSong(


### PR DESCRIPTION
## Summary
- configure `ffmpeg-static` with play-dl when available

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684a378ac4cc832587cdb0e96752ceae