### PR TITLE
Fix YouTube stream fallback

### DIFF
--- a/src/__tests__/music.test.ts
+++ b/src/__tests__/music.test.ts
@@ -375,7 +375,14 @@ describe('Comandos de Música', () => {
       );
 
       expect(ytdl).toHaveBeenCalledWith('https://example.com/song', {
-        filter: 'audioonly'
+        filter: 'audioonly',
+        quality: 'highestaudio',
+        requestOptions: {
+          headers: expect.objectContaining({
+            cookie: expect.any(String),
+            'User-Agent': expect.stringContaining('Mozilla/')
+          })
+        }
       });
     });
 

--- a/src/music.ts
+++ b/src/music.ts
@@ -19,6 +19,7 @@ import {
 import play from 'play-dl';
 import { Readable } from 'stream';
 import ytdl from 'ytdl-core';
+import ffmpegPath from 'ffmpeg-static';
 import { i18n } from './i18n';
 import {
   MUSIC_CHANNEL_ID,
@@ -28,6 +29,10 @@ import {
 
 if (YOUTUBE_COOKIE) {
   play.setToken({ youtube: { cookie: YOUTUBE_COOKIE } });
+}
+
+if (ffmpegPath) {
+  process.env.FFMPEG_PATH = ffmpegPath;
 }
 
 export async function findNextSong(
@@ -164,8 +169,18 @@ async function playUrl(client: Client, url: string): Promise<void> {
     type = res.type;
   } catch (err) {
     console.warn('⚠️ play-dl failed, trying ytdl-core', err);
-    stream = ytdl(url, { filter: 'audioonly' });
-    type = StreamType.Arbitrary;
+    stream = ytdl(url, {
+      filter: 'audioonly',
+      quality: 'highestaudio',
+      requestOptions: {
+        headers: {
+          cookie: YOUTUBE_COOKIE,
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0'
+        }
+      }
+    });
+    type = StreamType.WebmOpus;
   }
   const resource = createAudioResource(stream, { inputType: type });
   const player = createAudioPlayer();


### PR DESCRIPTION
## Summary
- set FFMPEG path for playback
- improve YouTube fallback using ytdl-core with headers
- adjust tests for new options

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head -n 20`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684a3eface64832583730efd0a9ce087