### PR TITLE
Fix zip missing xhr worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ npm run build-zip
 This archive includes a `serverConfig.json` file used by the `/setup` command to
 store guild and channel information. The bot searches for this file in `src/`
 first and falls back to the repository root if not found. If a `cookies.txt`
-file is present it will also be bundled.
+file is present it will also be bundled. The `xhr-sync-worker.js` file required
+by jsdom is also packaged to avoid runtime errors.
 
 ### Commands
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -106,6 +106,7 @@ npm run build-zip
 
 Esse arquivo inclui `serverConfig.json` usado pelo comando `/setup` para armazenar informações de guild e canal.
 Se houver um `cookies.txt` na pasta raiz, ele também será incluído no pacote.
+O arquivo `xhr-sync-worker.js` necessário pelo jsdom também é incluído para evitar erros em tempo de execução.
 
 ### Comandos
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run copy-assets && npm run compile && npm run bundle",
     "start": "node build/index.js",
     "dev": "ts-node src/index.ts",
-    "generate-zip": "rm -f bot.zip && cd build && zip -r ../bot.zip index.js users.json serverConfig.json i18n/ && if [ -f cookies.txt ]; then zip ../bot.zip cookies.txt; fi && zip -j ../bot.zip ../package.json ../.env",
+    "generate-zip": "rm -f bot.zip && cd build && zip -r ../bot.zip index.js xhr-sync-worker.js users.json serverConfig.json i18n/ && if [ -f cookies.txt ]; then zip ../bot.zip cookies.txt; fi && zip -j ../bot.zip ../package.json ../.env",
     "build-zip": "npm run clean && npm run build && npm run generate-zip",
     "lint": "eslint \"src/**/*.ts\" && tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",


### PR DESCRIPTION
## Summary
- package xhr-sync-worker.js with production zip
- document extra file in README and README.pt-br

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head -n 20`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684a5b0166b0832590c599a7baba584e