### PR TITLE
Implement enhanced /select behavior

### DIFF
--- a/src/__tests__/__mocks__/i18n.ts
+++ b/src/__tests__/__mocks__/i18n.ts
@@ -16,6 +16,7 @@ export const i18n = {
       'user.registered': '✅ User {{name}} has been registered!',
       'user.selfRegistered': '✅ You have been registered!',
       'user.removed': '✅ User {{name}} has been removed!',
+      'daily.announcement': 'announce <@{{id}}> ({{name}})',
       'selection.resetOriginal': '✅ Selection list has been reset to original state.',
       'selection.resetAll': '✅ {{count}} users have been readded to the selection list.',
       'selection.readded': '✅ {{name}} has been readded to the selection list.'

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -120,6 +120,25 @@ describe('handlers', () => {
     expect(interaction.reply).toHaveBeenCalled();
   });
 
+  test('handleSelect readds previous user on same day', async () => {
+    const userA = { name: 'A', id: '1' };
+    const userB = { name: 'B', id: '2' };
+    data.all.push(userA, userB);
+    data.remaining.push(userA, userB);
+    const today = new Date().toISOString().split('T')[0];
+    mockSelectUser.mockResolvedValueOnce(userA);
+    const interaction = createInteraction();
+    await handleSelect(interaction, data);
+    data.lastSelected = userA;
+    data.lastSelectionDate = today;
+    data.remaining = [userB];
+    mockSelectUser.mockResolvedValueOnce(userB);
+    await handleSelect(interaction, data);
+    expect(data.remaining.some((u) => u.id === '1')).toBe(true);
+    const msg = (interaction.reply as jest.Mock).mock.calls[1][0];
+    expect(String(msg)).toContain('selection.readded');
+  });
+
   test('handleReset loads original file', async () => {
     (mockFs.promises.readFile as jest.Mock).mockResolvedValue(
       JSON.stringify({ all: [] })

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -127,10 +127,21 @@ export async function handleSelect(
   interaction: ChatInputCommandInteraction,
   data: UserData
 ): Promise<void> {
+  const today = todayISO();
+  let message = '';
+  if (data.lastSelected && data.lastSelectionDate === today) {
+    if (!data.remaining.some((u) => u.id === data.lastSelected!.id)) {
+      data.remaining.push(data.lastSelected);
+    }
+    message += i18n.t('selection.readded', { name: data.lastSelected.name }) +
+      '\n';
+  }
   const selected = await selectUser(data);
-  await interaction.reply(
-    i18n.t('selection.nextUser', { id: selected.id, name: selected.name })
-  );
+  message += i18n.t('daily.announcement', {
+    id: selected.id,
+    name: selected.name
+  });
+  await interaction.reply(message);
 }
 
 export async function handleReset(

--- a/src/users.sample.json
+++ b/src/users.sample.json
@@ -7,5 +7,6 @@
     {"name": "Sample User 1", "id": "1"},
     {"name": "Sample User 2", "id": "2"}
   ],
-  "lastSelected": null
+  "lastSelected": null,
+  "lastSelectionDate": null
 }

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { USERS_FILE } from './config';
 import { i18n } from './i18n';
+import { todayISO } from './date';
 
 export interface UserEntry {
   name: string;
@@ -11,6 +12,8 @@ export interface UserData {
   all: UserEntry[];
   remaining: UserEntry[];
   lastSelected?: UserEntry;
+  /** ISO date string of the last selection */
+  lastSelectionDate?: string;
   skips?: Record<string, string>;
 }
 
@@ -56,6 +59,7 @@ export async function selectUser(data: UserData): Promise<UserEntry> {
   const selected = eligible[index];
   data.remaining = data.remaining.filter(u => u.id !== selected.id);
   data.lastSelected = selected;
+  data.lastSelectionDate = todayISO();
   await saveUsers(data);
   return selected;
 }


### PR DESCRIPTION
## Summary
- add lastSelectionDate to user data
- re-add previous daily user when /select runs again on the same day
- announce selection using daily announcement message
- update test mocks and add regression test

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head -n 20`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684b402750188325a96acb5ca1bcb774