### PR TITLE
feat: accept user id or mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ by jsdom is also packaged to avoid runtime errors.
 - `register <name>` – register a user by name
 - `clear-bunnies` – remove bunny reactions added by the bot
 - `check-config` – verify if the bot configuration is complete.
-- `remove <name>` – remove a user
+- `remove <user>` – remove a user (mention, id or name)
 - `reset` – reset selection list (or restore original list)
-- `readd <name>` – re-add a previously selected user back into the pool
+- `readd <user>` – re-add a previously selected user back into the pool (mention, id or name)
 - `skip-today <user>` – skip today's draw for the specified user (mention, id or name)
 - `skip-until <user> <date>` – skip selection of a user until the given date (format defined by `DATE_FORMAT`, default `YYYY-MM-DD`; user can be mention, id or name)
 - `setup` – configure channels, guild ID and other settings. Provide only the parameters you want to update.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -124,9 +124,9 @@ O arquivo `xhr-sync-worker.js` necessário pelo jsdom também é incluído para 
 - `registrar <nome>` – registra um usuário pelo nome
 - `limpar-coelhos` – remove reações de coelhinho adicionadas pelo bot
 - `verificar-config` – verifica se a configuração do bot está completa.
-- `remover <nome>` – remove um usuário
+- `remover <usuario>` – remove um usuário (menção, id ou nome)
 - `resetar` – reseta a lista de seleção (ou restaura a lista original)
-- `readicionar <nome>` – readiciona um usuário previamente selecionado
+- `readicionar <usuario>` – readiciona um usuário previamente selecionado (menção, id ou nome)
 - `pular-hoje <usuario>` – pula o sorteio de hoje para o usuário informado (menção, id ou nome)
 - `pular-ate <usuario> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`; usuário pode ser menção, id ou nome)
 - `configurar` – configura canais, ID da guild e outras definições. Informe apenas os parâmetros que deseja atualizar.

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -101,6 +101,17 @@ describe('handlers', () => {
     expect(mockSaveUsers).toHaveBeenCalled();
   });
 
+  test('handleRemove accepts id and mention', async () => {
+    data.all.push({ name: 'Tester', id: '10' });
+    data.remaining.push({ name: 'Tester', id: '10' });
+    await handleRemove(createInteraction({ name: '10' }), data);
+    expect(data.all.length).toBe(0);
+    data.all.push({ name: 'Other', id: '20' });
+    data.remaining.push({ name: 'Other', id: '20' });
+    await handleRemove(createInteraction({ name: '<@20>' }), data);
+    expect(data.all.length).toBe(0);
+  });
+
   test('handleList replies with formatted lists', async () => {
     data.all.push({ name: 'A', id: '1' });
     const interaction = createInteraction();
@@ -135,6 +146,15 @@ describe('handlers', () => {
     await handleReadd(interaction, data);
     expect(data.remaining.length).toBe(1);
     expect(mockSaveUsers).toHaveBeenCalled();
+  });
+
+  test('handleReadd accepts id and mention', async () => {
+    data.all.push({ name: 'B', id: '2' });
+    await handleReadd(createInteraction({ name: '2' }), data);
+    expect(data.remaining.length).toBe(1);
+    data.remaining = [];
+    await handleReadd(createInteraction({ name: '<@2>' }), data);
+    expect(data.remaining.length).toBe(1);
   });
 
   test('handleSkipToday sets skip for today', async () => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -84,7 +84,7 @@
       "options": {
         "name": {
           "name": "name",
-          "description": "User name"
+          "description": "User (mention, id or name)"
         }
       }
     },

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -89,7 +89,7 @@
       "options": {
         "name": {
           "name": "nome",
-          "description": "Nome do usuário"
+          "description": "Usuário (menção, id ou nome)"
         }
       }
     },


### PR DESCRIPTION
## Summary
- allow `/remove` and `/readd` to parse users by mention, id or name
- document new parameter behaviour
- update translations for `readd`
- test new user identifiers

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684b3f779094832598251e91fce5e4c4