### PR TITLE
Add enable/disable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ DAILY_DAYS=1-5
 HOLIDAY_COUNTRIES=BR
 USERS_FILE=./src/users.json
 DATE_FORMAT=YYYY-MM-DD
+DISABLED_UNTIL=
 ADMIN_IDS=1234567890,0987654321
 
 ```
@@ -77,6 +78,7 @@ syntax (e.g. `1-5` for Monday–Friday). `HOLIDAY_COUNTRIES` is a comma-separate
 list of country codes (currently `BR` and `US` are supported).
 `DATE_FORMAT` controls the date pattern used for the `/skip-until` command and
 can also be changed via `/setup`.
+`DISABLED_UNTIL` can set an ISO date to pause daily announcements until that day.
 
 ## Usage
 
@@ -138,6 +140,8 @@ by jsdom is also packaged to avoid runtime errors.
 - `readd <user>` – re-add a previously selected user back into the pool (mention, id or name)
 - `skip-today <user>` – skip today's draw for the specified user (mention, id or name)
 - `skip-until <user> <date>` – skip selection of a user until the given date (format defined by `DATE_FORMAT`, default `YYYY-MM-DD`; user can be mention, id or name)
+- `disable [date]` – disable daily announcements (optionally until the given date)
+- `enable` – re-enable daily announcements
 - `setup` – configure channels, guild ID and other settings. Provide only the parameters you want to update.
 - `export` – export data files
 - `import` – import runtime data files

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -63,12 +63,14 @@ HOLIDAY_COUNTRIES=BR
 USERS_FILE=./src/users.json
 ADMIN_IDS=1234567890,0987654321
 DATE_FORMAT=YYYY-MM-DD
+DISABLED_UNTIL=
 
 ```
 `ADMIN_IDS` deve listar os IDs dos usuários do Discord que iniciam com direitos de administrador. Você também pode editar `serverConfig.json` para gerenciar a lista.
 
 
 Defina `BOT_LANGUAGE` como `en` ou `pt-br` para alterar as respostas do bot. `DAILY_TIME` usa o formato 24h `HH:MM` e `DAILY_DAYS` segue a sintaxe de dia da semana do cron (ex.: `1-5` para segunda a sexta). `HOLIDAY_COUNTRIES` é uma lista separada por vírgulas de códigos de país (`BR` e `US` são suportados). `DATE_FORMAT` controla o padrão de data usado pelo comando `/skip-until` e também pode ser alterado via `/setup`.
+`DISABLED_UNTIL` permite definir uma data ISO para pausar os anúncios diários até esse dia.
 
 ## Uso
 
@@ -129,6 +131,8 @@ O arquivo `xhr-sync-worker.js` necessário pelo jsdom também é incluído para 
 - `readicionar <usuario>` – readiciona um usuário previamente selecionado (menção, id ou nome)
 - `pular-hoje <usuario>` – pula o sorteio de hoje para o usuário informado (menção, id ou nome)
 - `pular-ate <usuario> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`; usuário pode ser menção, id ou nome)
+- `desativar [data]` – desativa os anúncios diários (opcionalmente até a data informada)
+- `ativar` – reativa os anúncios diários
 - `configurar` – configura canais, ID da guild e outras definições. Informe apenas os parâmetros que deseja atualizar.
 - `exportar` – exporta arquivos de dados
 - `importar` – importa arquivos de dados

--- a/src/__tests__/scheduler.test.ts
+++ b/src/__tests__/scheduler.test.ts
@@ -58,4 +58,31 @@ describe('scheduleDailySelection', () => {
 
     expect(send).not.toHaveBeenCalled();
   });
+
+  test('does nothing when disabled until future date', async () => {
+    const cron = await import('node-cron');
+    const mockSchedule = jest.fn((expr: string, fn: () => void) => {
+      fn();
+      return { stop: jest.fn() } as unknown as import('node-cron').ScheduledTask;
+    });
+    (cron.schedule as jest.Mock).mockImplementation(mockSchedule);
+
+    jest.doMock('../holidays', () => ({ isHoliday: () => false }));
+    jest.doMock('../i18n', () => ({ i18n: { t: jest.fn(() => 'msg') } }));
+    jest.doMock('../users', () => ({
+      loadUsers: jest.fn().mockResolvedValue({}),
+      selectUser: jest.fn().mockResolvedValue({ id: '1', name: 'Test' })
+    }));
+    jest.doMock('../music', () => ({
+      findNextSong: jest.fn().mockResolvedValue({ text: 'song', components: [] })
+    }));
+    const config = await import('../config');
+    config.CHANNEL_ID = '1';
+    config.DISABLED_UNTIL = '2999-12-31';
+    const { scheduleDailySelection } = await import('../scheduler');
+    scheduleDailySelection(client);
+    await Promise.resolve();
+
+    expect(send).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -104,7 +104,8 @@ describe('serverConfig module', () => {
       dailyDays: '1-5',
       holidayCountries: ['BR', 'US'],
       dateFormat: 'YYYY-MM-DD',
-      admins: ['x']
+      admins: ['x'],
+      disabledUntil: '2025-01-01'
     });
     expect(config.GUILD_ID).toBe('g');
     expect(config.CHANNEL_ID).toBe('c');
@@ -118,5 +119,6 @@ describe('serverConfig module', () => {
     expect(config.HOLIDAY_COUNTRIES).toEqual(['BR', 'US']);
     expect(config.DATE_FORMAT).toBe('YYYY-MM-DD');
     expect(config.ADMINS).toEqual(['x']);
+    expect(config.DISABLED_UNTIL).toBe('2025-01-01');
   });
 });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,7 +26,9 @@ import {
   handleExport,
   handleImport,
   handleCheckConfig,
-  handleRole
+  handleRole,
+  handleDisable,
+  handleEnable
 } from './handlers';
 import {
   handleNextSong,
@@ -240,6 +242,20 @@ export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
           .setRequired(true)
       ),
     new SlashCommandBuilder()
+      .setName(i18n.getCommandName('disable'))
+      .setDescription(i18n.getCommandDescription('disable'))
+      .addStringOption((option) =>
+        option
+          .setName(i18n.getOptionName('disable', 'date'))
+          .setDescription(
+            i18n.t('commands.disable.options.date.description', { format: DATE_FORMAT })
+          )
+          .setRequired(false)
+      ),
+    new SlashCommandBuilder()
+      .setName(i18n.getCommandName('enable'))
+      .setDescription(i18n.getCommandDescription('enable')),
+    new SlashCommandBuilder()
       .setName(i18n.getCommandName('check-config'))
       .setDescription(i18n.getCommandDescription('check-config'))
   ].map((cmd) => cmd.toJSON());
@@ -258,7 +274,9 @@ export function createAdminCommands(): Set<string> {
     i18n.getCommandName('role'),
     i18n.getCommandName('clear-bunnies'),
     i18n.getCommandName('check-config'),
-    i18n.getCommandName('register')
+    i18n.getCommandName('register'),
+    i18n.getCommandName('disable'),
+    i18n.getCommandName('enable')
   ]);
 }
 
@@ -301,6 +319,12 @@ export function createCommandHandlers(): Record<string, CommandHandler> {
     },
     [i18n.getCommandName('check-config')]: async (interaction) => {
       await handleCheckConfig(interaction);
+    },
+    [i18n.getCommandName('disable')]: async (interaction) => {
+      await handleDisable(interaction);
+    },
+    [i18n.getCommandName('enable')]: async (interaction) => {
+      await handleEnable(interaction);
     }
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export let HOLIDAY_COUNTRIES = (
   .filter((c) => c);
 export let DATE_FORMAT =
   process.env.DATE_FORMAT || fileConfig?.dateFormat || 'YYYY-MM-DD';
+export let DISABLED_UNTIL = process.env.DISABLED_UNTIL || fileConfig?.disabledUntil || '';
 const envAdmins = process.env.ADMIN_IDS;
 export let ADMINS: string[] = envAdmins
   ? envAdmins
@@ -68,6 +69,7 @@ export function updateServerConfig(config: ServerConfig): void {
   if (config.dailyDays) DAILY_DAYS = config.dailyDays;
   if (config.holidayCountries) HOLIDAY_COUNTRIES = config.holidayCountries;
   if (config.dateFormat) DATE_FORMAT = config.dateFormat;
+  if (config.disabledUntil !== undefined) DISABLED_UNTIL = config.disabledUntil;
   if (config.admins && !envAdmins) ADMINS = config.admins;
 }
 
@@ -84,7 +86,8 @@ export function logConfig(): void {
 
       `ADMINS=${ADMINS.length}`,
       `USERS=${USERS_FILE}`,
-      `DATE_FMT=${DATE_FORMAT}`
+      `DATE_FMT=${DATE_FORMAT}`,
+      `DISABLED_UNTIL=${DISABLED_UNTIL || 'none'}`
     ].join(' | ')
   );
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -189,15 +189,29 @@
       "name": "check-config",
       "description": "Verify bot configuration"
     },
-    "role": {
-      "name": "role",
-      "description": "Set user role",
-      "options": {
-        "user": { "name": "user", "description": "Target user" },
-        "role": { "name": "role", "description": "Role" }
+      "role": {
+        "name": "role",
+        "description": "Set user role",
+        "options": {
+          "user": { "name": "user", "description": "Target user" },
+          "role": { "name": "role", "description": "Role" }
+        }
+      },
+      "disable": {
+        "name": "disable",
+        "description": "Disable daily announcements",
+        "options": {
+          "date": {
+            "name": "date",
+            "description": "Enable again on date ({{format}})"
+          }
+        }
+      },
+      "enable": {
+        "name": "enable",
+        "description": "Enable daily announcements"
       }
-    }
-  },
+    },
   "import.success": "✅ Data imported successfully.",
   "import.invalid": "❌ Invalid or missing files.",
   "config.valid": "✅ Configuration looks good.",
@@ -210,6 +224,9 @@
   "selection.nextUser": "➡️ Selected user: <@{{id}}> ({{name}})",
   "selection.resetOriginal": "✅ Selection list has been reset to original state.",
   "selection.resetAll": "✅ {{count}} users have been readded to the selection list.",
-  "errors.unauthorized": "❌ You do not have permission to use this command.",
-  "role.updated": "✅ {{name}} is now {{role}}."
-}
+    "errors.unauthorized": "❌ You do not have permission to use this command.",
+    "role.updated": "✅ {{name}} is now {{role}}.",
+    "bot.disabled": "⏸️ Daily announcements disabled.",
+    "bot.disabledUntil": "⏸️ Daily announcements disabled until {{date}}.",
+    "bot.enabled": "✅ Daily announcements enabled."
+  }

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -194,15 +194,29 @@
       "name": "verificar-config",
       "description": "Verifica a configuração do bot"
     },
-    "role": {
-      "name": "role",
-      "description": "Define o papel de um usuário",
-      "options": {
-        "user": { "name": "usuario", "description": "Usuário" },
-        "role": { "name": "papel", "description": "Papel" }
+      "role": {
+        "name": "role",
+        "description": "Define o papel de um usuário",
+        "options": {
+          "user": { "name": "usuario", "description": "Usuário" },
+          "role": { "name": "papel", "description": "Papel" }
+        }
+      },
+      "disable": {
+        "name": "desativar",
+        "description": "Desativa os anúncios diários",
+        "options": {
+          "date": {
+            "name": "data",
+            "description": "Reativar em ({{format}})"
+          }
+        }
+      },
+      "enable": {
+        "name": "ativar",
+        "description": "Ativa os anúncios diários"
       }
-    }
-  },
+    },
   "import.success": "✅ Dados importados com sucesso.",
   "import.invalid": "❌ Arquivos inválidos ou ausentes.",
   "config.valid": "✅ Configuração correta.",
@@ -210,6 +224,9 @@
   "user.alreadyRegistered": "❌ Usuário {{name}} já está registrado.",
   "user.alreadySelfRegistered": "❌ Você já está registrado(a).",
   "selection.nextUser": "➡️ Próximo usuário selecionado: <@{{id}}> ({{name}})",
-  "errors.unauthorized": "❌ Você não tem permissão para usar este comando.",
-  "role.updated": "✅ {{name}} agora é {{role}}."
-}
+    "errors.unauthorized": "❌ Você não tem permissão para usar este comando.",
+    "role.updated": "✅ {{name}} agora é {{role}}.",
+    "bot.disabled": "⏸️ Anúncios diários desativados.",
+    "bot.disabledUntil": "⏸️ Anúncios diários desativados até {{date}}.",
+    "bot.enabled": "✅ Anúncios diários ativados."
+  }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -7,10 +7,12 @@ import {
   TIMEZONE,
   DAILY_TIME,
   DAILY_DAYS,
-  HOLIDAY_COUNTRIES
+  HOLIDAY_COUNTRIES,
+  DISABLED_UNTIL
 } from './config';
 import { loadUsers, selectUser } from './users';
 import { findNextSong } from './music';
+import { todayISO } from './date';
 
 let dailyJob: cron.ScheduledTask | null = null;
 
@@ -25,6 +27,10 @@ export function scheduleDailySelection(client: Client): void {
   dailyJob = cron.schedule(
     cronExpr,
     async () => {
+      if (DISABLED_UNTIL && todayISO() <= DISABLED_UNTIL) {
+        console.log(`⏸️ Bot disabled until ${DISABLED_UNTIL}`);
+        return;
+      }
       if (isHoliday(new Date(), HOLIDAY_COUNTRIES)) {
         console.log(i18n.t('daily.holiday'));
         return;

--- a/src/serverConfig.sample.json
+++ b/src/serverConfig.sample.json
@@ -11,5 +11,6 @@
   "dailyDays": "1-5",
   "holidayCountries": ["BR"],
   "dateFormat": "YYYY-MM-DD",
+  "disabledUntil": "",
   "admins": []
 }

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -14,6 +14,7 @@ export interface ServerConfig {
   dailyDays?: string;
   holidayCountries?: string[];
   dateFormat?: string;
+  disabledUntil?: string;
   admins?: string[];
 }
 


### PR DESCRIPTION
## Summary
- add admin commands `/disable` and `/enable`
- store disabled date in config and serverConfig
- support disabling scheduler when date hasn't passed
- document new commands and config option
- update translations
- test disabled scheduler and config update

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_686841ce822083258e30b964ef7ecf81