### PR TITLE
Move configuration to serverConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Discord bot that automatically selects a random user each weekday and manages mu
 
 - Slash commands to register users, list participants and manage selections
 - Daily selection at a configurable time and weekdays
-  (timezone and holiday countries can be set via environment variables)
+  (timezone and holiday countries are configured via `serverConfig.json`)
 - Slash command names are also available in Portuguese (pt-br)
 - Music utilities to fetch songs and play them directly in a voice channel (with a stop command)
 - Optional multilingual responses (English default, Portuguese-BR available)
@@ -45,31 +45,16 @@ npm install
 
 ## Configuration
 
-Create an `.env` file with the following variables:
+Copy `src/serverConfig.sample.json` to `src/serverConfig.json` and
+fill in the desired values. All settings such as token, guild ID,
+channel IDs and scheduling options are read from this file. Only
+`NODE_ENV` and `USERS_FILE` are read from environment variables.
 
-```
-DISCORD_TOKEN=your-bot-token
-# If omitted, run `/setup` in your server to set the token, guild and channel ids.
-GUILD_ID=your-guild-id
-CHANNEL_ID=id-of-channel-for-daily-messages
-MUSIC_CHANNEL_ID=id-of-channel-with-song-requests
-PLAYER_FORWARD_COMMAND=m!play
-# Optional
-DAILY_VOICE_CHANNEL_ID=id-of-voice-channel-to-play-songs
-TIMEZONE=America/Sao_Paulo
-BOT_LANGUAGE=en
-DAILY_TIME=09:00
-DAILY_DAYS=1-5
-HOLIDAY_COUNTRIES=BR
-USERS_FILE=./src/users.json
-DATE_FORMAT=YYYY-MM-DD
-DISABLED_UNTIL=
-ADMIN_IDS=1234567890,0987654321
+`USERS_FILE` can point to a custom path for user data; otherwise the
+default `src/users.json` will be used.
 
-```
-
-`ADMIN_IDS` should list the Discord user IDs that start with admin rights. You can also
-edit `serverConfig.json` (either inside `src/` or at the repository root) to manage the list.
+The `admins` field in `serverConfig.json` defines which Discord user IDs
+start with admin rights.
 
 
 Set `BOT_LANGUAGE` to `en` or `pt-br` to change the bot responses.
@@ -154,7 +139,7 @@ Two roles are available: **admin** and **user**. All members listed in
 `users.json` start as **user**. Admin IDs are stored in `serverConfig.json` and a
 Discord user does not need to be registered to become an admin.
 
-The initial admin list can be provided using the `ADMIN_IDS` environment variable or the `admins` field in the config file.
+The initial admin list can be defined in the `admins` field of `serverConfig.json`.
 
 Only admins may run privileged commands such as `/register`, `/clear-bunnies`,
 `/check-config`, `/setup`, `/import`, `/export`, `/skip-*` and `/role` itself.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -6,7 +6,7 @@ Bot do Discord que seleciona automaticamente um usuário aleatório a cada dia �
 ## Recursos
 
 - Comandos de barra para registrar usuários, listar participantes e gerenciar seleções
-- Seleção diária em horário e dias configuráveis (fuso horário e países de feriado podem ser definidos por variáveis de ambiente)
+- Seleção diária em horário e dias configuráveis (fuso horário e países de feriado são definidos em `serverConfig.json`)
 - Nomes dos comandos também estão disponíveis em português (pt-br)
 - Utilidades de música para tocar músicas diretamente em um canal de voz (inclui comando para parar)
 - Respostas multilíngues opcionais (inglês por padrão e português-BR disponível)
@@ -44,29 +44,16 @@ npm install
 
 ## Configuração
 
-Crie um arquivo `.env` com as seguintes variáveis:
+Copie `src/serverConfig.sample.json` para `src/serverConfig.json` e
+preencha os valores desejados. Todas as configurações como token,
+IDs de guild e canais são lidas desse arquivo. Somente `NODE_ENV` e
+`USERS_FILE` são lidos de variáveis de ambiente.
 
-```
-DISCORD_TOKEN=seu-token
-# Caso omitido, execute `/setup` no seu servidor para definir token, guild e canal.
-GUILD_ID=id-da-sua-guild
-CHANNEL_ID=id-do-canal-de-mensagens-diarias
-MUSIC_CHANNEL_ID=id-do-canal-de-pedidos-de-musica
-PLAYER_FORWARD_COMMAND=m!play
-# Opcional
-DAILY_VOICE_CHANNEL_ID=id-do-canal-de-voz-para-tocar-musicas
-TIMEZONE=America/Sao_Paulo
-BOT_LANGUAGE=en
-DAILY_TIME=09:00
-DAILY_DAYS=1-5
-HOLIDAY_COUNTRIES=BR
-USERS_FILE=./src/users.json
-ADMIN_IDS=1234567890,0987654321
-DATE_FORMAT=YYYY-MM-DD
-DISABLED_UNTIL=
+`USERS_FILE` pode apontar para um caminho personalizado de dados dos
+usuários; caso contrário o padrão `src/users.json` será utilizado.
 
-```
-`ADMIN_IDS` deve listar os IDs dos usuários do Discord que iniciam com direitos de administrador. Você também pode editar `serverConfig.json` para gerenciar a lista.
+O campo `admins` em `serverConfig.json` define quais IDs de usuário do
+Discord começam com direitos de administrador.
 
 
 Defina `BOT_LANGUAGE` como `en` ou `pt-br` para alterar as respostas do bot. `DAILY_TIME` usa o formato 24h `HH:MM` e `DAILY_DAYS` segue a sintaxe de dia da semana do cron (ex.: `1-5` para segunda a sexta). `HOLIDAY_COUNTRIES` é uma lista separada por vírgulas de códigos de país (`BR` e `US` são suportados). `DATE_FORMAT` controla o padrão de data usado pelo comando `/skip-until` e também pode ser alterado via `/setup`.
@@ -144,7 +131,7 @@ O arquivo `xhr-sync-worker.js` necessário pelo jsdom também é incluído para 
 
 Dois papéis estão disponíveis: **admin** e **user**. Todos os membros listados em `users.json` começam como **user**. Os IDs de administradores são armazenados em `serverConfig.json` e um usuário do Discord não precisa estar registrado para se tornar administrador.
 
-A lista inicial de administradores pode ser fornecida usando a variável de ambiente `ADMIN_IDS` ou o campo `admins` no arquivo de configuração.
+A lista inicial de administradores deve ser definida no campo `admins` do arquivo `serverConfig.json`.
 
 Somente administradores podem executar comandos privilegiados como `/registrar`, `/limpar-coelhos`, `/verificar-config`, `/configurar`, `/importar`, `/exportar`, `/pular-*` e o próprio `/role`. Usuários comuns ainda podem usar comandos básicos como `/entrar`, `/listar`, `/selecionar`, `/proxima-musica` e `/parar-musica`.
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 
 // Configurar variáveis de ambiente para teste
 process.env.USERS_FILE = path.join(__dirname, 'users.test.json');
-process.env.DATE_FORMAT = 'YYYY-MM-DD';
 
 // Garantir que o arquivo de teste existe
 if (!fs.existsSync(process.env.USERS_FILE)) {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -41,12 +41,20 @@ test('canUseAdminCommands respects roles', async () => {
   await expect(config.canUseAdminCommands('2')).resolves.toBe(false);
 });
 
-test('ADMINS loaded from environment variable', async () => {
-  process.env.ADMIN_IDS = 'a,b';
+
+test('ADMINS loaded from config file', async () => {
+  jest.doMock('fs', () => ({
+    existsSync: jest.fn().mockReturnValue(true),
+    readFileSync: jest
+      .fn()
+      .mockReturnValue(
+        JSON.stringify({ admins: ['a', 'b'] })
+      ),
+    promises: { writeFile: jest.fn() }
+  }));
   jest.resetModules();
   const cfg = await import('../config');
   expect(cfg.ADMINS).toEqual(['a', 'b']);
-  delete process.env.ADMIN_IDS;
 });
 
 test('reloadServerConfig updates values from file', async () => {

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -2,7 +2,6 @@ import { jest } from '@jest/globals';
 
 beforeEach(() => {
   jest.resetModules();
-  process.env.DATE_FORMAT = 'YYYY-MM-DD';
 });
 
 describe('date utilities', () => {

--- a/src/__tests__/index.runtime.test.ts
+++ b/src/__tests__/index.runtime.test.ts
@@ -66,10 +66,20 @@ describe('index runtime', () => {
     jest.resetModules();
     jest.unmock('fs');
     process.env.NODE_ENV = 'development';
-    process.env.DISCORD_TOKEN = 't';
-    process.env.GUILD_ID = 'g';
-    process.env.CHANNEL_ID = 'c';
-    process.env.MUSIC_CHANNEL_ID = 'm';
+    jest.doMock('fs', () => ({
+      existsSync: jest.fn().mockReturnValue(true),
+      readFileSync: jest
+        .fn()
+        .mockReturnValue(
+          JSON.stringify({
+            token: 't',
+            guildId: 'g',
+            channelId: 'c',
+            musicChannelId: 'm'
+          })
+        ),
+      promises: { writeFile: jest.fn() }
+    }));
   });
 
   test('initializes client and schedules daily selection', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,45 +9,27 @@ dotenv.config();
 
 const fileConfig = loadServerConfig();
 
-export let TOKEN = process.env.DISCORD_TOKEN || fileConfig?.token || '';
+export let TOKEN = fileConfig?.token || '';
 
-export let CHANNEL_ID = process.env.CHANNEL_ID || fileConfig?.channelId || '';
-export let GUILD_ID = process.env.GUILD_ID || fileConfig?.guildId || '';
-export let MUSIC_CHANNEL_ID =
-  process.env.MUSIC_CHANNEL_ID || fileConfig?.musicChannelId || '';
-export let DAILY_VOICE_CHANNEL_ID =
-  process.env.DAILY_VOICE_CHANNEL_ID || fileConfig?.dailyVoiceChannelId || '';
-export let PLAYER_FORWARD_COMMAND =
-  process.env.PLAYER_FORWARD_COMMAND || fileConfig?.playerForwardCommand || '';
+export let CHANNEL_ID = fileConfig?.channelId || '';
+export let GUILD_ID = fileConfig?.guildId || '';
+export let MUSIC_CHANNEL_ID = fileConfig?.musicChannelId || '';
+export let DAILY_VOICE_CHANNEL_ID = fileConfig?.dailyVoiceChannelId || '';
+export let PLAYER_FORWARD_COMMAND = fileConfig?.playerForwardCommand || '';
 
 export const USERS_FILE = process.env.USERS_FILE
   ? path.resolve(process.env.USERS_FILE)
   : path.join(__dirname, 'users.json');
-export let TIMEZONE =
-  process.env.TIMEZONE || fileConfig?.timezone || 'America/Sao_Paulo';
-export let LANGUAGE =
-  process.env.BOT_LANGUAGE || fileConfig?.language || 'pt-br';
-export let DAILY_TIME =
-  process.env.DAILY_TIME || fileConfig?.dailyTime || '09:00';
-export let DAILY_DAYS =
-  process.env.DAILY_DAYS || fileConfig?.dailyDays || '1-5';
-export let HOLIDAY_COUNTRIES = (
-  process.env.HOLIDAY_COUNTRIES ||
-  (fileConfig?.holidayCountries ? fileConfig.holidayCountries.join(',') : 'BR')
-)
-  .split(',')
-  .map((c) => c.trim().toUpperCase())
-  .filter((c) => c);
-export let DATE_FORMAT =
-  process.env.DATE_FORMAT || fileConfig?.dateFormat || 'YYYY-MM-DD';
-export let DISABLED_UNTIL = process.env.DISABLED_UNTIL || fileConfig?.disabledUntil || '';
-const envAdmins = process.env.ADMIN_IDS;
-export let ADMINS: string[] = envAdmins
-  ? envAdmins
-      .split(',')
-      .map((a) => a.trim())
-      .filter((a) => a)
-  : fileConfig?.admins || [];
+export let TIMEZONE = fileConfig?.timezone || 'America/Sao_Paulo';
+export let LANGUAGE = fileConfig?.language || 'pt-br';
+export let DAILY_TIME = fileConfig?.dailyTime || '09:00';
+export let DAILY_DAYS = fileConfig?.dailyDays || '1-5';
+export let HOLIDAY_COUNTRIES = (fileConfig?.holidayCountries || ['BR']).map((c) =>
+  c.trim().toUpperCase()
+);
+export let DATE_FORMAT = fileConfig?.dateFormat || 'YYYY-MM-DD';
+export let DISABLED_UNTIL = fileConfig?.disabledUntil || '';
+export let ADMINS: string[] = fileConfig?.admins || [];
 
 const rbac = RBAC({ enableLogger: true })({
   user: { can: ['basic'] },
@@ -70,7 +52,7 @@ export function updateServerConfig(config: ServerConfig): void {
   if (config.holidayCountries) HOLIDAY_COUNTRIES = config.holidayCountries;
   if (config.dateFormat) DATE_FORMAT = config.dateFormat;
   if (config.disabledUntil !== undefined) DISABLED_UNTIL = config.disabledUntil;
-  if (config.admins && !envAdmins) ADMINS = config.admins;
+  if (config.admins) ADMINS = config.admins;
 }
 
 export function logConfig(): void {


### PR DESCRIPTION
## Summary
- load runtime options only from `serverConfig.json`
- adjust tests for new configuration approach
- update documentation on configuring the bot

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head -n 20`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68684a90bd8883258f73e94b044dc962