### PR TITLE
feat: show changed fields on setup

### DIFF
--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -23,6 +23,8 @@ jest.mock('../i18n', () => ({
       const translations: Record<string, string> = {
         'selection.readded': 'selection.readded',
         'setup.invalidDateFormat': 'setup.invalidDateFormat',
+        'setup.savedDetailed': 'setup.savedDetailed',
+        'setup.savedNoChanges': 'setup.savedNoChanges',
         'config.valid': 'config.valid',
         'config.invalid': 'config.invalid'
       };
@@ -375,7 +377,7 @@ describe('handlers', () => {
     });
     expect(updateServerConfig).toHaveBeenCalled();
     expect(scheduleDailySelection).toHaveBeenCalledWith(interaction.client);
-    expect(interaction.reply).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith('setup.savedDetailed');
     expect(res).toBe(true);
   });
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -360,7 +360,44 @@ export async function handleSetup(
   await saveServerConfig(cfg);
   updateServerConfig(cfg);
   scheduleDailySelection(interaction.client);
-  await interaction.reply(i18n.t('setup.saved'));
+
+  const changes: string[] = [];
+  if (cfg.channelId !== existing.channelId)
+    changes.push(i18n.getOptionName('setup', 'daily'));
+  if (cfg.musicChannelId !== existing.musicChannelId)
+    changes.push(i18n.getOptionName('setup', 'music'));
+  if (cfg.dailyVoiceChannelId !== existing.dailyVoiceChannelId)
+    changes.push(i18n.getOptionName('setup', 'voice'));
+  if (cfg.playerForwardCommand !== existing.playerForwardCommand)
+    changes.push(i18n.getOptionName('setup', 'player'));
+  if (cfg.token !== existing.token)
+    changes.push(i18n.getOptionName('setup', 'token'));
+  if (cfg.guildId !== existing.guildId)
+    changes.push(i18n.getOptionName('setup', 'guild'));
+  if (cfg.timezone !== existing.timezone)
+    changes.push(i18n.getOptionName('setup', 'timezone'));
+  if (cfg.language !== existing.language)
+    changes.push(i18n.getOptionName('setup', 'language'));
+  if (cfg.dailyTime !== existing.dailyTime)
+    changes.push(i18n.getOptionName('setup', 'dailyTime'));
+  if (cfg.dailyDays !== existing.dailyDays)
+    changes.push(i18n.getOptionName('setup', 'dailyDays'));
+  if (
+    (cfg.holidayCountries ?? []).join(',') !==
+    (existing.holidayCountries ?? []).join(',')
+  )
+    changes.push(i18n.getOptionName('setup', 'holidayCountries'));
+  if (cfg.dateFormat !== existing.dateFormat)
+    changes.push(i18n.getOptionName('setup', 'dateFormat'));
+
+  const changedFields = changes.join(', ');
+  if (changes.length > 0) {
+    await interaction.reply(
+      i18n.t('setup.savedDetailed', { fields: changedFields })
+    );
+  } else {
+    await interaction.reply(i18n.t('setup.savedNoChanges'));
+  }
   return language !== existing.language || guildId !== existing.guildId;
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -24,6 +24,8 @@
   "selection.noEligibleUsers": "❌ No eligible users to select.",
   "user.notFound": "❌ User {{name}} not found.",
   "setup.saved": "✅ Configuration saved!",
+  "setup.savedDetailed": "✅ Configuration saved! Updated: {{fields}}.",
+  "setup.savedNoChanges": "✅ Configuration saved! No changes detected.",
   "setup.instructions": "Use /setup to configure channels and token.",
   "setup.invalidDateFormat": "❌ Invalid date format. Use placeholders YYYY, MM and DD.",
   

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -29,6 +29,8 @@
   "user.selfRegistered": "✅ Você foi registrado(a) com sucesso!",
   "user.removed": "✅ Usuário {{name}} foi removido com sucesso!",
   "setup.saved": "✅ Configuração salva!",
+  "setup.savedDetailed": "✅ Configuração salva! Campos atualizados: {{fields}}.",
+  "setup.savedNoChanges": "✅ Configuração salva! Nenhuma alteração detectada.",
   "setup.instructions": "Use /configurar para definir canais e token.",
   "setup.invalidDateFormat": "❌ Formato de data inválido. Use YYYY, MM e DD.",
   


### PR DESCRIPTION
## Summary
- show which fields changed when saving configuration
- add new translations for setup feedback
- test handleSetup reply message

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68684cd39f7083258450e181fbcdc0e1