### PR TITLE
Increase test coverage

### DIFF
--- a/src/__tests__/music.test.ts
+++ b/src/__tests__/music.test.ts
@@ -495,5 +495,38 @@ describe('Comandos de Música', () => {
         components: undefined
       });
     });
+
+    it('deve retornar erro se não conseguir acessar o canal', async () => {
+      (mockClientInstance.channels as unknown as MockChannelManager).fetch.mockResolvedValueOnce(null);
+
+      await handleClearReactions(
+        mockInteraction as unknown as ChatInputCommandInteraction
+      );
+
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: mockTranslations['music.channelError']
+      });
+    });
+
+    it('deve informar quando nenhuma reação foi removida', async () => {
+      const messageWithoutReaction = {
+        ...mockMessageInstance,
+        reactions: { cache: new MockCollection() }
+      };
+
+      (mockClientInstance.channels as unknown as MockChannelManager).fetch.mockResolvedValue(mockChannelInstance);
+      mockChannelInstance.messages.fetch.mockResolvedValue(
+        new MockCollection([['123', messageWithoutReaction]])
+      );
+
+      await handleClearReactions(
+        mockInteraction as unknown as ChatInputCommandInteraction
+      );
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: mockTranslations['music.reactionsCleared'].replace('{{count}}', '0'),
+        components: undefined
+      });
+    });
   });
 });

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -51,6 +51,17 @@ describe('serverConfig module', () => {
     expect(loadServerConfig()).toBeNull();
   });
 
+  test('loadServerConfig falls back to root path', async () => {
+    const data = { guildId: '9', channelId: '8', musicChannelId: '7' };
+    jest.doMock('fs', () => ({
+      existsSync: jest.fn((p: string) => !p.includes('/src/')),
+      readFileSync: jest.fn().mockReturnValue(JSON.stringify(data)),
+      promises: { writeFile: jest.fn() }
+    }));
+    const { loadServerConfig } = await import('../serverConfig');
+    expect(loadServerConfig()).toEqual(data);
+  });
+
   test('saveServerConfig writes config to file', async () => {
     const writeFile = jest.fn();
     jest.doMock('fs', () => ({

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -1,0 +1,28 @@
+import { findUser, UserData } from '../users';
+
+describe('findUser', () => {
+  const data: UserData = {
+    all: [
+      { name: 'Alice', id: '1' },
+      { name: 'Bob', id: '2' }
+    ],
+    remaining: []
+  };
+
+  it('finds by user mention', () => {
+    expect(findUser(data, '<@1>')?.name).toBe('Alice');
+    expect(findUser(data, '<@!2>')?.name).toBe('Bob');
+  });
+
+  it('finds by id string', () => {
+    expect(findUser(data, '2')).toEqual({ name: 'Bob', id: '2' });
+  });
+
+  it('finds by username', () => {
+    expect(findUser(data, 'Alice')).toEqual({ name: 'Alice', id: '1' });
+  });
+
+  it('returns undefined when not found', () => {
+    expect(findUser(data, 'Charlie')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for finding users
- add tests for more music reaction cases
- cover server config root fallback

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6868514e501c83258b7888012302bccf