### PR TITLE
Implement locale-based date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Set `BOT_LANGUAGE` to `en` or `pt-br` to change the bot responses.
 syntax (e.g. `1-5` for Monday–Friday). `HOLIDAY_COUNTRIES` is a comma-separated
 list of country codes (currently `BR` and `US` are supported).
 `DATE_FORMAT` controls the date pattern used for the `/skip-until` command and
-can also be changed via `/setup`.
+can also be changed via `/setup`. When `BOT_LANGUAGE` is `pt-br`, the default
+format becomes `DD-MM-YYYY`.
 `DISABLED_UNTIL` can set an ISO date to pause daily announcements until that day.
 
 ## Usage

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -56,7 +56,7 @@ O campo `admins` em `serverConfig.json` define quais IDs de usuário do
 Discord começam com direitos de administrador.
 
 
-Defina `BOT_LANGUAGE` como `en` ou `pt-br` para alterar as respostas do bot. `DAILY_TIME` usa o formato 24h `HH:MM` e `DAILY_DAYS` segue a sintaxe de dia da semana do cron (ex.: `1-5` para segunda a sexta). `HOLIDAY_COUNTRIES` é uma lista separada por vírgulas de códigos de país (`BR` e `US` são suportados). `DATE_FORMAT` controla o padrão de data usado pelo comando `/skip-until` e também pode ser alterado via `/setup`.
+Defina `BOT_LANGUAGE` como `en` ou `pt-br` para alterar as respostas do bot. `DAILY_TIME` usa o formato 24h `HH:MM` e `DAILY_DAYS` segue a sintaxe de dia da semana do cron (ex.: `1-5` para segunda a sexta). `HOLIDAY_COUNTRIES` é uma lista separada por vírgulas de códigos de país (`BR` e `US` são suportados). `DATE_FORMAT` controla o padrão de data usado pelo comando `/skip-until` e também pode ser alterado via `/setup`. O idioma `pt-br` usa por padrão `DD-MM-YYYY`.
 `DISABLED_UNTIL` permite definir uma data ISO para pausar os anúncios diários até esse dia.
 
 ## Uso
@@ -117,9 +117,9 @@ O arquivo `xhr-sync-worker.js` necessário pelo jsdom também é incluído para 
 - `resetar` – reseta a lista de seleção (ou restaura a lista original)
 - `readicionar <usuario>` – readiciona um usuário previamente selecionado (menção, id ou nome)
 - `pular-hoje <usuario>` – pula o sorteio de hoje para o usuário informado (menção, id ou nome)
-- `pular-ate <usuario> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`; usuário pode ser menção, id ou nome)
+- `pular-ate <usuario> <data>` – pula a seleção de um usuário até a data especificada (formato definido por `DATE_FORMAT`, padrão `DD-MM-YYYY`; usuário pode ser menção, id ou nome)
 - `desativar` – desativa os anúncios diários por tempo indeterminado
-- `desativar-ate <data>` – desativa os anúncios diários até a data informada (formato definido por `DATE_FORMAT`, padrão `YYYY-MM-DD`)
+- `desativar-ate <data>` – desativa os anúncios diários até a data informada (formato definido por `DATE_FORMAT`, padrão `DD-MM-YYYY`)
 - `ativar` – reativa os anúncios diários
 - `configurar` – configura canais, ID da guild e outras definições. Informe apenas os parâmetros que deseja atualizar.
 - `exportar` – exporta arquivos de dados

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -6,16 +6,19 @@ beforeEach(() => {
 
 describe('date utilities', () => {
   test('parseDateString returns iso date when valid', async () => {
+    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const { parseDateString } = await import('../date');
     expect(parseDateString('2024-12-31')).toBe('2024-12-31');
   });
 
   test('parseDateString returns null for invalid format', async () => {
+    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const { parseDateString } = await import('../date');
     expect(parseDateString('31/12/2024')).toBeNull();
   });
 
   test('parseDateString keeps value for out-of-range date', async () => {
+    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const { parseDateString } = await import('../date');
     expect(parseDateString('2024-02-30')).toBe('2024-02-30');
   });
@@ -25,6 +28,12 @@ describe('date utilities', () => {
     const { todayISO } = await import('../date');
     expect(todayISO()).toBe('2024-05-20');
     jest.useRealTimers();
+  });
+
+  test('formatDateString follows DATE_FORMAT', async () => {
+    jest.doMock('../config', () => ({ DATE_FORMAT: 'DD-MM-YYYY' }));
+    const { formatDateString } = await import('../date');
+    expect(formatDateString('2024-07-08')).toBe('08-07-2024');
   });
 
   test('isDateFormatValid detects valid patterns', async () => {

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -327,6 +327,8 @@ describe('handlers', () => {
 
   test('handleSkipUntil sets future skip', async () => {
     data.all.push({ name: 'A', id: '1' });
+    jest.resetModules();
+    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const future = '2099-01-01';
     const interaction = createInteraction({ name: 'A', date: future });
     const { handleSkipUntil } = await import('../handlers');
@@ -337,6 +339,8 @@ describe('handlers', () => {
 
   test('handleSkipUntil accepts id and mention', async () => {
     data.all.push({ name: 'A', id: '1' });
+    jest.resetModules();
+    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const future = '2099-01-01';
     const { handleSkipUntil } = await import('../handlers');
     await handleSkipUntil(createInteraction({ name: '1', date: future }), data);

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,12 @@ export let DAILY_DAYS = fileConfig?.dailyDays || '1-5';
 export let HOLIDAY_COUNTRIES = (fileConfig?.holidayCountries || ['BR']).map((c) =>
   c.trim().toUpperCase()
 );
-export let DATE_FORMAT = fileConfig?.dateFormat || 'YYYY-MM-DD';
+function defaultDateFormat(lang: string): string {
+  return lang === 'pt-br' ? 'DD-MM-YYYY' : 'YYYY-MM-DD';
+}
+
+export let DATE_FORMAT =
+  fileConfig?.dateFormat || defaultDateFormat(LANGUAGE);
 export let DISABLED_UNTIL = fileConfig?.disabledUntil || '';
 export let ADMINS: string[] = fileConfig?.admins || [];
 
@@ -50,7 +55,11 @@ export function updateServerConfig(config: ServerConfig): void {
   if (config.dailyTime) DAILY_TIME = config.dailyTime;
   if (config.dailyDays) DAILY_DAYS = config.dailyDays;
   if (config.holidayCountries) HOLIDAY_COUNTRIES = config.holidayCountries;
-  if (config.dateFormat) DATE_FORMAT = config.dateFormat;
+  if (config.dateFormat) {
+    DATE_FORMAT = config.dateFormat;
+  } else if (config.language) {
+    DATE_FORMAT = defaultDateFormat(config.language);
+  }
   if (config.disabledUntil !== undefined) DISABLED_UNTIL = config.disabledUntil;
   if (config.admins) ADMINS = config.admins;
 }

--- a/src/date.ts
+++ b/src/date.ts
@@ -43,3 +43,8 @@ export function parseDateString(input: string): string | null {
 export function todayISO(): string {
   return new Date().toISOString().split('T')[0];
 }
+
+export function formatDateString(iso: string): string {
+  const [year, month, day] = iso.split('-');
+  return DATE_FORMAT.replace('YYYY', year).replace('MM', month).replace('DD', day);
+}

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -11,7 +11,12 @@ import {
   formatUsers,
   findUser
 } from './users';
-import { parseDateString, todayISO, isDateFormatValid } from './date';
+import {
+  parseDateString,
+  todayISO,
+  isDateFormatValid,
+  formatDateString
+} from './date';
 import * as config from './config';
 const {
   DATE_FORMAT,
@@ -264,7 +269,7 @@ export async function handleSkipUntil(
   data.skips[user.id] = iso;
   await saveUsers(data);
   await interaction.reply(
-    i18n.t('selection.skipUntil', { name: userName, date: iso })
+    i18n.t('selection.skipUntil', { name: userName, date: formatDateString(iso) })
   );
 }
 
@@ -550,7 +555,9 @@ export async function handleDisableUntil(
   existing.disabledUntil = parsed;
   await saveServerConfig(existing);
   updateServerConfig(existing);
-  await interaction.reply(i18n.t('bot.disabledUntil', { date: parsed }));
+  await interaction.reply(
+    i18n.t('bot.disabledUntil', { date: formatDateString(parsed) })
+  );
 }
 
 export async function handleEnable(

--- a/src/serverConfig.sample.json
+++ b/src/serverConfig.sample.json
@@ -10,7 +10,7 @@
   "dailyTime": "09:00",
   "dailyDays": "1-5",
   "holidayCountries": ["BR"],
-  "dateFormat": "YYYY-MM-DD",
+  "dateFormat": "DD-MM-YYYY",
   "disabledUntil": "",
   "admins": []
 }


### PR DESCRIPTION
## Summary
- default PT-BR date format to `DD-MM-YYYY`
- adjust config update logic to reflect language defaults
- format dates shown to users using `formatDateString`
- document Portuguese default format in READMEs
- update tests for new behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip | head -n 20`
- `NODE_ENV=test node build/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6868539aa7c48325b8a73284998c0a98