### PR TITLE
refactor: use alias imports

### DIFF
--- a/src/__tests__/__mocks__/discord.js.ts
+++ b/src/__tests__/__mocks__/discord.js.ts
@@ -1,4 +1,4 @@
-import { MockCollection } from './MockCollection';
+import { MockCollection } from '@/__tests__/__mocks__/MockCollection';
 
 export class MockActionRowBuilder {
   private readonly components: unknown[] = [];

--- a/src/__tests__/__mocks__/i18n.ts
+++ b/src/__tests__/__mocks__/i18n.ts
@@ -1,4 +1,4 @@
-import { i18n as realI18n, Language } from '../../i18n';
+import { i18n as realI18n, Language } from '@/i18n';
 
 export const i18n = {
   ...realI18n,

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -1,6 +1,6 @@
-import { createAdminCommands } from '../commands';
+import { createAdminCommands } from '@/commands';
 
-jest.mock('../i18n', () => ({
+jest.mock('@/i18n', () => ({
   i18n: {
     getCommandName: (c: string) => c,
     getCommandDescription: jest.fn(),

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -3,7 +3,7 @@ beforeEach(() => {
 });
 
 test('checkRequiredConfig returns missing fields', async () => {
-  const config = await import('../config');
+  const config = await import('@/config');
   config.TOKEN = '';
   config.GUILD_ID = '';
   config.CHANNEL_ID = '';
@@ -18,7 +18,7 @@ test('checkRequiredConfig returns missing fields', async () => {
 });
 
 test('isConfigValid returns true when all fields set', async () => {
-  const config = await import('../config');
+  const config = await import('@/config');
   config.TOKEN = 't';
   config.GUILD_ID = 'g';
   config.CHANNEL_ID = 'c';
@@ -28,14 +28,14 @@ test('isConfigValid returns true when all fields set', async () => {
 });
 
 test('isAdmin checks list', async () => {
-  const config = await import('../config');
+  const config = await import('@/config');
   config.ADMINS = ['1'];
   expect(config.isAdmin('1')).toBe(true);
   expect(config.isAdmin('2')).toBe(false);
 });
 
 test('canUseAdminCommands respects roles', async () => {
-  const config = await import('../config');
+  const config = await import('@/config');
   config.ADMINS = ['1'];
   await expect(config.canUseAdminCommands('1')).resolves.toBe(true);
   await expect(config.canUseAdminCommands('2')).resolves.toBe(false);
@@ -53,7 +53,7 @@ test('ADMINS loaded from config file', async () => {
     promises: { writeFile: jest.fn() }
   }));
   jest.resetModules();
-  const cfg = await import('../config');
+  const cfg = await import('@/config');
   expect(cfg.ADMINS).toEqual(['a', 'b']);
 });
 
@@ -71,7 +71,7 @@ test('reloadServerConfig updates values from file', async () => {
       ),
     promises: { writeFile: jest.fn() }
   }));
-  const cfg = await import('../config');
+  const cfg = await import('@/config');
   cfg.reloadServerConfig();
   expect(cfg.GUILD_ID).toBe('g1');
   expect(cfg.CHANNEL_ID).toBe('c1');

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -6,44 +6,44 @@ beforeEach(() => {
 
 describe('date utilities', () => {
   test('parseDateString returns iso date when valid', async () => {
-    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
-    const { parseDateString } = await import('../date');
+    jest.doMock('@/config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
+    const { parseDateString } = await import('@/date');
     expect(parseDateString('2024-12-31')).toBe('2024-12-31');
   });
 
   test('parseDateString returns null for invalid format', async () => {
-    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
-    const { parseDateString } = await import('../date');
+    jest.doMock('@/config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
+    const { parseDateString } = await import('@/date');
     expect(parseDateString('31/12/2024')).toBeNull();
   });
 
   test('parseDateString keeps value for out-of-range date', async () => {
-    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
-    const { parseDateString } = await import('../date');
+    jest.doMock('@/config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
+    const { parseDateString } = await import('@/date');
     expect(parseDateString('2024-02-30')).toBe('2024-02-30');
   });
 
   test('todayISO returns current date', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-05-20T12:34:56Z'));
-    const { todayISO } = await import('../date');
+    const { todayISO } = await import('@/date');
     expect(todayISO()).toBe('2024-05-20');
     jest.useRealTimers();
   });
 
   test('formatDateString follows DATE_FORMAT', async () => {
-    jest.doMock('../config', () => ({ DATE_FORMAT: 'DD-MM-YYYY' }));
-    const { formatDateString } = await import('../date');
+    jest.doMock('@/config', () => ({ DATE_FORMAT: 'DD-MM-YYYY' }));
+    const { formatDateString } = await import('@/date');
     expect(formatDateString('2024-07-08')).toBe('08-07-2024');
   });
 
   test('isDateFormatValid detects valid patterns', async () => {
-    const { isDateFormatValid } = await import('../date');
+    const { isDateFormatValid } = await import('@/date');
     expect(isDateFormatValid('YYYY-MM-DD')).toBe(true);
     expect(isDateFormatValid('DD/MM/YYYY')).toBe(true);
   });
 
   test('isDateFormatValid detects invalid patterns', async () => {
-    const { isDateFormatValid } = await import('../date');
+    const { isDateFormatValid } = await import('@/date');
     expect(isDateFormatValid('YYYY/DD')).toBe(false);
     expect(isDateFormatValid('ABC')).toBe(false);
   });

--- a/src/__tests__/handlers.test.ts
+++ b/src/__tests__/handlers.test.ts
@@ -14,10 +14,10 @@ import {
   handleExport,
   handleImport,
   handleCheckConfig
-} from '../handlers';
-import { UserData } from '../users';
+} from '@/handlers';
+import { UserData } from '@/users';
 
-jest.mock('../i18n', () => ({
+jest.mock('@/i18n', () => ({
   i18n: {
     t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
@@ -46,8 +46,8 @@ const mockFormatUsers = jest.fn(
     '(none)'
 );
 
-jest.mock('../users', () => {
-  const actual = jest.requireActual('../users');
+jest.mock('@/users', () => {
+  const actual = jest.requireActual('@/users');
   return {
     ...actual,
     saveUsers: (data: UserData) => mockSaveUsers(data),
@@ -309,7 +309,7 @@ describe('handlers', () => {
     data.all.push({ name: 'A', id: '1' });
     const interaction = createInteraction({ name: 'A' });
     const today = new Date().toISOString().split('T')[0];
-    const { handleSkipToday } = await import('../handlers');
+    const { handleSkipToday } = await import('@/handlers');
     await handleSkipToday(interaction, data);
     expect(data.skips?.['1']).toBe(today);
     expect(mockSaveUsers).toHaveBeenCalled();
@@ -318,7 +318,7 @@ describe('handlers', () => {
   test('handleSkipToday accepts id and mention', async () => {
     data.all.push({ name: 'A', id: '1' });
     const today = new Date().toISOString().split('T')[0];
-    const { handleSkipToday } = await import('../handlers');
+    const { handleSkipToday } = await import('@/handlers');
     await handleSkipToday(createInteraction({ name: '1' }), data);
     expect(data.skips?.['1']).toBe(today);
     await handleSkipToday(createInteraction({ name: '<@1>' }), data);
@@ -328,10 +328,10 @@ describe('handlers', () => {
   test('handleSkipUntil sets future skip', async () => {
     data.all.push({ name: 'A', id: '1' });
     jest.resetModules();
-    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
+    jest.doMock('@/config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const future = '2099-01-01';
     const interaction = createInteraction({ name: 'A', date: future });
-    const { handleSkipUntil } = await import('../handlers');
+    const { handleSkipUntil } = await import('@/handlers');
     await handleSkipUntil(interaction, data);
     expect(data.skips?.['1']).toBe(future);
     expect(mockSaveUsers).toHaveBeenCalled();
@@ -340,9 +340,9 @@ describe('handlers', () => {
   test('handleSkipUntil accepts id and mention', async () => {
     data.all.push({ name: 'A', id: '1' });
     jest.resetModules();
-    jest.doMock('../config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
+    jest.doMock('@/config', () => ({ DATE_FORMAT: 'YYYY-MM-DD' }));
     const future = '2099-01-01';
-    const { handleSkipUntil } = await import('../handlers');
+    const { handleSkipUntil } = await import('@/handlers');
     await handleSkipUntil(createInteraction({ name: '1', date: future }), data);
     expect(data.skips?.['1']).toBe(future);
     await handleSkipUntil(createInteraction({ name: '<@1>', date: future }), data);
@@ -354,14 +354,14 @@ describe('handlers', () => {
     const { saveServerConfig, updateServerConfig, scheduleDailySelection } = setupBasicMocks();
     
     jest.doMock('https', () => createMockHttpsModule());
-    jest.doMock('../serverConfig', () => ({
+    jest.doMock('@/serverConfig', () => ({
       saveServerConfig,
       loadServerConfig: jest.fn().mockReturnValue(createMockServerConfig())
     }));
-    jest.doMock('../config', () => createMockConfig(updateServerConfig));
-    jest.doMock('../scheduler', () => ({ scheduleDailySelection }));
+    jest.doMock('@/config', () => createMockConfig(updateServerConfig));
+    jest.doMock('@/scheduler', () => ({ scheduleDailySelection }));
     
-    const { handleSetup } = await import('../handlers');
+    const { handleSetup } = await import('@/handlers');
     const interaction = createMockInteractionForSetup();
     const res = await handleSetup(interaction);
     
@@ -390,14 +390,14 @@ describe('handlers', () => {
     const saveServerConfig = jest.fn();
     const updateServerConfig = jest.fn();
     
-    jest.doMock('../serverConfig', () => ({
+    jest.doMock('@/serverConfig', () => ({
       saveServerConfig,
       loadServerConfig: jest.fn().mockReturnValue(createMockServerConfig())
     }));
-    jest.doMock('../config', () => createMockConfig(updateServerConfig));
-    jest.doMock('../scheduler', () => ({ scheduleDailySelection: jest.fn() }));
+    jest.doMock('@/config', () => createMockConfig(updateServerConfig));
+    jest.doMock('@/scheduler', () => ({ scheduleDailySelection: jest.fn() }));
     
-    const { handleSetup } = await import('../handlers');
+    const { handleSetup } = await import('@/handlers');
     const interaction = {
       guildId: 'g',
       options: {
@@ -418,8 +418,8 @@ describe('handlers', () => {
   test('handleSetup ignores missing guildId', async () => {
     jest.resetModules();
     const saveServerConfig = jest.fn();
-    jest.doMock('../serverConfig', () => ({ saveServerConfig }));
-    const { handleSetup } = await import('../handlers');
+    jest.doMock('@/serverConfig', () => ({ saveServerConfig }));
+    const { handleSetup } = await import('@/handlers');
     const interaction = {
       guildId: undefined,
       options: { getChannel: jest.fn(), getString: jest.fn(), getAttachment: jest.fn() },
@@ -475,18 +475,18 @@ describe('handlers', () => {
       existsSync: jest.fn(),
       readFileSync: jest.fn()
     }));
-    jest.doMock('../serverConfig', () => ({
+    jest.doMock('@/serverConfig', () => ({
       saveServerConfig,
       loadServerConfig: jest.fn(),
       ServerConfig: {}
     }));
-    jest.doMock('../config', () => ({
+    jest.doMock('@/config', () => ({
       USERS_FILE: 'users.json',
       updateServerConfig
     }));
-    jest.doMock('../scheduler', () => ({ scheduleDailySelection }));
+    jest.doMock('@/scheduler', () => ({ scheduleDailySelection }));
     
-    const { handleImport } = await import('../handlers');
+    const { handleImport } = await import('@/handlers');
     const interaction = {
       options: {
         getAttachment: jest
@@ -510,7 +510,7 @@ describe('handlers', () => {
     jest.resetModules();
     jest.doMock('https', () => createMockHttpsModule());
     
-    const { handleImport } = await import('../handlers');
+    const { handleImport } = await import('@/handlers');
     const interaction = {
       options: {
         getAttachment: jest
@@ -528,9 +528,9 @@ describe('handlers', () => {
 
   test('handleCheckConfig reports valid config', async () => {
     jest.resetModules();
-    jest.dontMock('../config');
+    jest.dontMock('@/config');
     const interaction = createInteraction();
-    const config = await import('../config');
+    const config = await import('@/config');
     config.updateServerConfig({
       guildId: 'g',
       channelId: 'c',
@@ -544,16 +544,16 @@ describe('handlers', () => {
       holidayCountries: ['BR'],
       dateFormat: 'YYYY-MM-DD'
     });
-    const { handleCheckConfig } = await import('../handlers');
+    const { handleCheckConfig } = await import('@/handlers');
     await handleCheckConfig(interaction);
     expect(interaction.reply).toHaveBeenCalledWith('config.valid');
   });
 
   test('handleCheckConfig reports missing config', async () => {
     jest.resetModules();
-    jest.dontMock('../config');
+    jest.dontMock('@/config');
     const interaction = createInteraction();
-    const config = await import('../config');
+    const config = await import('@/config');
     config.updateServerConfig({
       guildId: '',
       channelId: '',
@@ -562,7 +562,7 @@ describe('handlers', () => {
       token: '',
       dateFormat: 'YYYY-MM-DD'
     });
-    const { handleCheckConfig } = await import('../handlers');
+    const { handleCheckConfig } = await import('@/handlers');
     await handleCheckConfig(interaction);
     expect(interaction.reply).toHaveBeenCalledWith('config.invalid');
   });
@@ -571,17 +571,17 @@ describe('handlers', () => {
     jest.resetModules();
     const saveServerConfig = jest.fn();
     const updateServerConfig = jest.fn();
-    jest.doMock('../serverConfig', () => ({
+    jest.doMock('@/serverConfig', () => ({
       saveServerConfig,
       loadServerConfig: jest.fn()
     }));
-    jest.doMock('../config', () => ({
+    jest.doMock('@/config', () => ({
       CHANNEL_ID: 'c',
       MUSIC_CHANNEL_ID: 'm',
       DATE_FORMAT: 'YYYY-MM-DD',
       updateServerConfig
     }));
-    const { handleDisable } = await import('../handlers');
+    const { handleDisable } = await import('@/handlers');
     const interaction = {
       guildId: 'g',
       options: { getString: jest.fn() },
@@ -600,17 +600,17 @@ describe('handlers', () => {
   test('handleDisableUntil validates date', async () => {
     jest.resetModules();
     const saveServerConfig = jest.fn();
-    jest.doMock('../serverConfig', () => ({
+    jest.doMock('@/serverConfig', () => ({
       saveServerConfig,
       loadServerConfig: jest.fn()
     }));
-    jest.doMock('../config', () => ({
+    jest.doMock('@/config', () => ({
       CHANNEL_ID: 'c',
       MUSIC_CHANNEL_ID: 'm',
       DATE_FORMAT: 'YYYY-MM-DD',
       updateServerConfig: jest.fn()
     }));
-    const { handleDisableUntil } = await import('../handlers');
+    const { handleDisableUntil } = await import('@/handlers');
     const interaction = {
       guildId: 'g',
       options: { getString: jest.fn(() => 'bad') },
@@ -625,17 +625,17 @@ describe('handlers', () => {
     jest.resetModules();
     const saveServerConfig = jest.fn();
     const updateServerConfig = jest.fn();
-    jest.doMock('../serverConfig', () => ({
+    jest.doMock('@/serverConfig', () => ({
       saveServerConfig,
       loadServerConfig: jest.fn()
     }));
-    jest.doMock('../config', () => ({
+    jest.doMock('@/config', () => ({
       CHANNEL_ID: 'c',
       MUSIC_CHANNEL_ID: 'm',
       DATE_FORMAT: 'YYYY-MM-DD',
       updateServerConfig
     }));
-    const { handleDisableUntil } = await import('../handlers');
+    const { handleDisableUntil } = await import('@/handlers');
     const interaction = {
       guildId: 'g',
       options: { getString: jest.fn(() => '2099-12-31') },

--- a/src/__tests__/holidays.test.ts
+++ b/src/__tests__/holidays.test.ts
@@ -3,7 +3,7 @@ import {
   getBrazilianHolidays,
   BRAZILIAN_FIXED_HOLIDAYS,
   getUSHolidays
-} from '../holidays';
+} from '@/holidays';
 
 describe('Módulo de Feriados', () => {
   describe('Feriados Fixos', () => {

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -36,7 +36,7 @@ describe('i18n module', () => {
   test('loads Portuguese command names', async () => {
     process.env.NODE_ENV = 'development';
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    const { i18n } = await import('../i18n');
+    const { i18n } = await import('@/i18n');
     i18n.setLanguage('pt-br');
     expect(i18n.getCommandName('list')).toBe('listar');
     expect(i18n.getCommandName('register')).toBe('registrar');
@@ -49,7 +49,7 @@ describe('i18n module', () => {
   test('logs fallback usage', async () => {
     process.env.NODE_ENV = 'development';
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    const { i18n } = await import('../i18n');
+    const { i18n } = await import('@/i18n');
     i18n.setLanguage('pt-br');
     i18n.t('nonexistent.key');
     expect(consoleSpy).toHaveBeenCalledWith(
@@ -59,14 +59,14 @@ describe('i18n module', () => {
   });
 
   test('formats daily announcement message', async () => {
-    const { i18n } = await import('../i18n');
+    const { i18n } = await import('@/i18n');
     i18n.setLanguage('en');
     const text = i18n.t('daily.announcement', { id: '42', name: 'Alice' });
     expect(text).toBe("Today's user: <@42> (Alice)");
   });
 
   test('returns holiday message', async () => {
-    const { i18n } = await import('../i18n');
+    const { i18n } = await import('@/i18n');
     i18n.setLanguage('pt-br');
     expect(i18n.t('daily.holiday')).toBe('Feriado');
   });

--- a/src/__tests__/index.runtime.test.ts
+++ b/src/__tests__/index.runtime.test.ts
@@ -59,7 +59,7 @@ jest.mock('discord.js', () => {
   };
 });
 
-jest.mock('../scheduler', () => ({ scheduleDailySelection: jest.fn() }));
+jest.mock('@/scheduler', () => ({ scheduleDailySelection: jest.fn() }));
 
 describe('index runtime', () => {
   beforeEach(() => {
@@ -83,8 +83,8 @@ describe('index runtime', () => {
   });
 
   test('initializes client and schedules daily selection', async () => {
-    const { scheduleDailySelection } = await import('../scheduler');
-    await import('../index');
+    const { scheduleDailySelection } = await import('@/scheduler');
+    await import('@/index');
     expect(createdClient.login).toHaveBeenCalledWith('t');
     const { Client: MockedClient, GatewayIntentBits } = await import('discord.js');
     const clientArgs = (MockedClient as unknown as jest.Mock).mock.calls[0][0];

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,7 +11,7 @@ jest.mock('fs', () => ({
   }
 }));
 
-jest.mock('../i18n', () => ({
+jest.mock('@/i18n', () => ({
   i18n: {
     t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
@@ -35,7 +35,7 @@ jest.mock('../i18n', () => ({
   }
 }));
 
-import { UserEntry, loadUsers, saveUsers, selectUser, formatUsers } from '../index';
+import { UserEntry, loadUsers, saveUsers, selectUser, formatUsers } from '@/index';
 
 
 // Mock do módulo fs
@@ -51,7 +51,7 @@ jest.mock('fs', () => ({
 }));
 
 // Mock do i18n
-jest.mock('../i18n', () => ({
+jest.mock('@/i18n', () => ({
   i18n: {
     t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
@@ -177,7 +177,7 @@ describe('Funções Utilitárias', () => {
     });
 
     it('deve manter a estrutura correta dos dados', async () => {
-      let savedData!: import('../index').UserData;
+      let savedData!: import('@/index').UserData;
       (fs.promises.writeFile as jest.Mock).mockImplementation((file, data) => {
         savedData = JSON.parse(data as string);
       });

--- a/src/__tests__/music.test.ts
+++ b/src/__tests__/music.test.ts
@@ -2,7 +2,7 @@ import {
   handleNextSong,
   handlePlayButton,
   handleClearReactions
-} from '../index';
+} from '@/index';
 import {
   Client,
   GatewayIntentBits,
@@ -17,12 +17,12 @@ import {
   ApplicationCommandType,
   ComponentType
 } from 'discord.js';
-import { MockCollection } from './__mocks__/MockCollection';
-import { mockChannel, mockMessageTemplate } from './__mocks__/discord.js';
+import { MockCollection } from '@/__tests__/__mocks__/MockCollection';
+import { mockChannel, mockMessageTemplate } from '@/__tests__/__mocks__/discord.js';
 
 // Mock do i18n
 var mockTranslations: Record<string, string>;
-jest.mock('../i18n', () => {
+jest.mock('@/i18n', () => {
   mockTranslations = {
     'list.empty': '(none)',
     'music.noValidMusic': '✅ No valid music found.',
@@ -158,7 +158,7 @@ describe('Comandos de Música', () => {
 
     jest.clearAllMocks();
 
-    const config = await import('../config');
+    const config = await import('@/config');
     config.MUSIC_CHANNEL_ID = 'requests';
     config.DAILY_VOICE_CHANNEL_ID = 'dailyVoice';
     config.PLAYER_FORWARD_COMMAND = '';
@@ -355,7 +355,7 @@ describe('Comandos de Música', () => {
     });
 
     it('deve orientar a usar outro bot quando configurado', async () => {
-      const config = await import('../config');
+      const config = await import('@/config');
       config.PLAYER_FORWARD_COMMAND = '/play';
 
       (
@@ -438,7 +438,7 @@ describe('Comandos de Música', () => {
 
   describe('handleStopMusic', () => {
     it('deve parar a reprodução e responder', async () => {
-      const music = await import('../music');
+      const music = await import('@/music');
       const queue = { delete: jest.fn() } as any;
       music.musicPlayer.instance = {
         extractors: { register: jest.fn() },

--- a/src/__tests__/scheduler.test.ts
+++ b/src/__tests__/scheduler.test.ts
@@ -20,20 +20,20 @@ describe('scheduleDailySelection', () => {
     });
     (cron.schedule as jest.Mock).mockImplementation(mockSchedule);
 
-    jest.doMock('../holidays', () => ({ isHoliday: () => false }));
-    jest.doMock('../i18n', () => ({
+    jest.doMock('@/holidays', () => ({ isHoliday: () => false }));
+    jest.doMock('@/i18n', () => ({
       i18n: { t: jest.fn(() => 'msg') }
     }));
-    jest.doMock('../users', () => ({
+    jest.doMock('@/users', () => ({
       loadUsers: jest.fn().mockResolvedValue({}),
       selectUser: jest.fn().mockResolvedValue({ id: '1', name: 'Test' })
     }));
-    jest.doMock('../music', () => ({
+    jest.doMock('@/music', () => ({
       findNextSong: jest.fn().mockResolvedValue({ text: 'song', components: [] })
     }));
-    const config = await import('../config');
+    const config = await import('@/config');
     config.CHANNEL_ID = '1';
-    const { scheduleDailySelection } = await import('../scheduler');
+    const { scheduleDailySelection } = await import('@/scheduler');
     scheduleDailySelection(client);
     await Promise.resolve();
 
@@ -48,11 +48,11 @@ describe('scheduleDailySelection', () => {
     });
     (cron.schedule as jest.Mock).mockImplementation(mockSchedule);
 
-    jest.doMock('../holidays', () => ({ isHoliday: () => true }));
-    jest.doMock('../i18n', () => ({ i18n: { t: jest.fn(() => 'holiday') } }));
-    const config = await import('../config');
+    jest.doMock('@/holidays', () => ({ isHoliday: () => true }));
+    jest.doMock('@/i18n', () => ({ i18n: { t: jest.fn(() => 'holiday') } }));
+    const config = await import('@/config');
     config.CHANNEL_ID = '1';
-    const { scheduleDailySelection } = await import('../scheduler');
+    const { scheduleDailySelection } = await import('@/scheduler');
     scheduleDailySelection(client);
     await Promise.resolve();
 
@@ -67,19 +67,19 @@ describe('scheduleDailySelection', () => {
     });
     (cron.schedule as jest.Mock).mockImplementation(mockSchedule);
 
-    jest.doMock('../holidays', () => ({ isHoliday: () => false }));
-    jest.doMock('../i18n', () => ({ i18n: { t: jest.fn(() => 'msg') } }));
-    jest.doMock('../users', () => ({
+    jest.doMock('@/holidays', () => ({ isHoliday: () => false }));
+    jest.doMock('@/i18n', () => ({ i18n: { t: jest.fn(() => 'msg') } }));
+    jest.doMock('@/users', () => ({
       loadUsers: jest.fn().mockResolvedValue({}),
       selectUser: jest.fn().mockResolvedValue({ id: '1', name: 'Test' })
     }));
-    jest.doMock('../music', () => ({
+    jest.doMock('@/music', () => ({
       findNextSong: jest.fn().mockResolvedValue({ text: 'song', components: [] })
     }));
-    const config = await import('../config');
+    const config = await import('@/config');
     config.CHANNEL_ID = '1';
     config.DISABLED_UNTIL = '2999-12-31';
-    const { scheduleDailySelection } = await import('../scheduler');
+    const { scheduleDailySelection } = await import('@/scheduler');
     scheduleDailySelection(client);
     await Promise.resolve();
 

--- a/src/__tests__/serverConfig.test.ts
+++ b/src/__tests__/serverConfig.test.ts
@@ -11,7 +11,7 @@ describe('serverConfig module', () => {
       readFileSync: jest.fn(),
       promises: { writeFile: jest.fn() }
     }));
-    const { loadServerConfig } = await import('../serverConfig');
+    const { loadServerConfig } = await import('@/serverConfig');
     expect(loadServerConfig()).toBeNull();
   });
 
@@ -35,7 +35,7 @@ describe('serverConfig module', () => {
       readFileSync: jest.fn().mockReturnValue(JSON.stringify(data)),
       promises: { writeFile: jest.fn() }
     }));
-    const { loadServerConfig } = await import('../serverConfig');
+    const { loadServerConfig } = await import('@/serverConfig');
     expect(loadServerConfig()).toEqual(data);
   });
 
@@ -47,7 +47,7 @@ describe('serverConfig module', () => {
       }),
       promises: { writeFile: jest.fn() }
     }));
-    const { loadServerConfig } = await import('../serverConfig');
+    const { loadServerConfig } = await import('@/serverConfig');
     expect(loadServerConfig()).toBeNull();
   });
 
@@ -58,7 +58,7 @@ describe('serverConfig module', () => {
       readFileSync: jest.fn().mockReturnValue(JSON.stringify(data)),
       promises: { writeFile: jest.fn() }
     }));
-    const { loadServerConfig } = await import('../serverConfig');
+    const { loadServerConfig } = await import('@/serverConfig');
     expect(loadServerConfig()).toEqual(data);
   });
 
@@ -69,7 +69,7 @@ describe('serverConfig module', () => {
       readFileSync: jest.fn(),
       promises: { writeFile }
     }));
-    const { saveServerConfig } = await import('../serverConfig');
+    const { saveServerConfig } = await import('@/serverConfig');
     const cfg = {
       guildId: '1',
       channelId: '2',
@@ -102,7 +102,7 @@ describe('serverConfig module', () => {
       readFileSync: jest.fn(),
       promises: { writeFile: jest.fn() }
     }));
-    const config = await import('../config');
+    const config = await import('@/config');
     config.updateServerConfig({
       guildId: 'g',
       channelId: 'c',

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -1,4 +1,4 @@
-import { findUser, UserData } from '../users';
+import { findUser, UserData } from '@/users';
 
 describe('findUser', () => {
   const data: UserData = {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -11,7 +11,7 @@ jest.mock('fs', () => ({
   }
 }));
 
-jest.mock('../i18n', () => ({
+jest.mock('@/i18n', () => ({
   i18n: {
     t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
@@ -40,7 +40,7 @@ import {
   type UserData,
   type UserEntry,
   formatUsers
-} from '../index';
+} from '@/index';
 
 // Mock do módulo fs
 jest.mock('fs', () => ({
@@ -159,7 +159,7 @@ jest.mock('discord.js', () => {
 });
 
 // Mock do i18n
-jest.mock('../i18n', () => ({
+jest.mock('@/i18n', () => ({
   i18n: {
     t: jest.fn((key: string, params: Record<string, string> = {}) => {
       const translations: Record<string, string> = {
@@ -289,7 +289,7 @@ describe('Funções Utilitárias', () => {
     });
 
     it('deve manter a estrutura correta dos dados', async () => {
-      let savedData!: import('../index').UserData;
+      let savedData!: import('@/index').UserData;
       (fs.promises.writeFile as jest.Mock).mockImplementation((file, data) => {
         savedData = JSON.parse(data as string);
       });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,12 +6,12 @@ import {
   Routes,
   type RESTPostAPIApplicationCommandsJSONBody
 } from 'discord.js';
-import { i18n } from './i18n';
+import { i18n } from '@/i18n';
 import {
   TOKEN,
   GUILD_ID,
   DATE_FORMAT
-} from './config';
+} from '@/config';
 import {
   handleRegister,
   handleJoin,
@@ -30,13 +30,13 @@ import {
   handleDisable,
   handleDisableUntil,
   handleEnable
-} from './handlers';
+} from '@/handlers';
 import {
   handleNextSong,
   handleClearReactions,
   handleStopMusic
-} from './music';
-import { UserData } from './users';
+} from '@/music';
+import { UserData } from '@/users';
 
 export function createCommands(): RESTPostAPIApplicationCommandsJSONBody[] {
   return [

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import * as dotenv from 'dotenv';
-import { loadServerConfig, ServerConfig } from './serverConfig';
+import { loadServerConfig, ServerConfig } from '@/serverConfig';
 import RBAC from '@rbac/rbac';
 
 

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,4 +1,4 @@
-import { DATE_FORMAT } from './config';
+import { DATE_FORMAT } from '@/config';
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as https from 'https';
 import { ChatInputCommandInteraction } from 'discord.js';
-import { i18n } from './i18n';
+import { i18n } from '@/i18n';
 import {
   UserEntry,
   UserData,
@@ -10,14 +10,14 @@ import {
   selectUser,
   formatUsers,
   findUser
-} from './users';
+} from '@/users';
 import {
   parseDateString,
   todayISO,
   isDateFormatValid,
   formatDateString
-} from './date';
-import * as config from './config';
+} from '@/date';
+import * as config from '@/config';
 const {
   DATE_FORMAT,
   updateServerConfig,
@@ -35,12 +35,12 @@ const {
   PLAYER_FORWARD_COMMAND,
   
 } = config;
-import { scheduleDailySelection } from './scheduler';
+import { scheduleDailySelection } from '@/scheduler';
 import {
   saveServerConfig,
   loadServerConfig,
   ServerConfig
-} from './serverConfig';
+} from '@/serverConfig';
 
 async function fetchText(url: string): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
   Partials,
   TextChannel
 } from 'discord.js';
-import { i18n } from './i18n';
+import { i18n } from '@/i18n';
 import {
   TOKEN,
   LANGUAGE,
@@ -13,7 +13,7 @@ import {
   checkRequiredConfig,
   canUseAdminCommands,
   reloadServerConfig
-} from './config';
+} from '@/config';
 import {
   UserData,
   UserEntry,
@@ -22,7 +22,7 @@ import {
   selectUser,
   formatUsers,
   findUser
-} from './users';
+} from '@/users';
 import {
   handleRegister,
   handleJoin,
@@ -37,16 +37,16 @@ import {
   handleImport,
   handleCheckConfig,
   handleRole
-} from './handlers';
-import { createCommands, createAdminCommands, createCommandHandlers, registerCommands } from "./commands";
+} from '@/handlers';
+import { createCommands, createAdminCommands, createCommandHandlers, registerCommands } from "@/commands";
 import {
   handleNextSong,
   findNextSong,
   handlePlayButton,
   handleClearReactions,
   handleStopMusic
-} from './music';
-import { scheduleDailySelection } from './scheduler';
+} from '@/music';
+import { scheduleDailySelection } from '@/scheduler';
 
 i18n.setLanguage(LANGUAGE as 'en' | 'pt-br');
 logConfig();

--- a/src/music.ts
+++ b/src/music.ts
@@ -12,12 +12,12 @@ import {
 import { Player } from 'discord-player';
 import { YoutubeiExtractor } from 'discord-player-youtubei';
 import ffmpegPath from 'ffmpeg-static';
-import { i18n } from './i18n';
+import { i18n } from '@/i18n';
 import {
   MUSIC_CHANNEL_ID,
   DAILY_VOICE_CHANNEL_ID,
   PLAYER_FORWARD_COMMAND
-} from './config';
+} from '@/config';
 
 if (ffmpegPath) {
   process.env.FFMPEG_PATH = ffmpegPath;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { Client, TextChannel } from 'discord.js';
 import * as cron from 'node-cron';
-import { isHoliday } from './holidays';
-import { i18n } from './i18n';
+import { isHoliday } from '@/holidays';
+import { i18n } from '@/i18n';
 import {
   CHANNEL_ID,
   TIMEZONE,
@@ -9,10 +9,10 @@ import {
   DAILY_DAYS,
   HOLIDAY_COUNTRIES,
   DISABLED_UNTIL
-} from './config';
-import { loadUsers, selectUser } from './users';
-import { findNextSong } from './music';
-import { todayISO } from './date';
+} from '@/config';
+import { loadUsers, selectUser } from '@/users';
+import { findNextSong } from '@/music';
+import { todayISO } from '@/date';
 
 let dailyJob: cron.ScheduledTask | null = null;
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
-import { USERS_FILE } from './config';
-import { i18n } from './i18n';
-import { todayISO } from './date';
+import { USERS_FILE } from '@/config';
+import { i18n } from '@/i18n';
+import { todayISO } from '@/date';
 
 export interface UserEntry {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "src/__tests__/**/*"]


### PR DESCRIPTION
## Summary
- configure TypeScript paths for `@/`
- refactor all internal imports to use alias

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build-zip`
- `unzip -l bot.zip`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68766154005c8325b65119c4a101a0b6