### PR TITLE
Handle selection when all users are skipped

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -288,5 +288,16 @@ describe('Funções Utilitárias', () => {
       expect(resultado).toBeDefined();
       expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
     });
+
+    it('deve reinserir usuários elegíveis quando todos restantes estão pulados', async () => {
+      const dados = JSON.parse(JSON.stringify(mockData));
+      dados.remaining = [{ name: 'User1', id: '1' }];
+      dados.skips = { '1': '2999-01-01' };
+
+      const resultado = await selectUser(dados);
+
+      expect(resultado.id).not.toBe('1');
+      expect(dados.remaining.length).toBe(5);
+    });
   });
 });

--- a/src/users.ts
+++ b/src/users.ts
@@ -60,7 +60,7 @@ export async function selectUser(data: UserData): Promise<UserEntry> {
     return today <= until;
   };
 
-  const eligible = data.remaining.filter(u => !isSkipped(u));
+  let eligible = data.remaining.filter(u => !isSkipped(u));
   
   // Salva os dados se houver skips expirados removidos
   if (hasExpiredSkips) {
@@ -68,7 +68,12 @@ export async function selectUser(data: UserData): Promise<UserEntry> {
   }
 
   if (eligible.length === 0) {
-    throw new Error(i18n.t('selection.noEligibleUsers'));
+    const allEligible = data.all.filter(u => !isSkipped(u));
+    if (allEligible.length === 0) {
+      throw new Error(i18n.t('selection.noEligibleUsers'));
+    }
+    data.remaining = [...allEligible];
+    eligible = [...allEligible];
   }
 
   const index = Math.floor(Math.random() * eligible.length);


### PR DESCRIPTION
## Summary
- reset remaining list when no users are eligible and retry selection
- test selection reset logic when remaining users are all skipped

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_688a2816015c832586d032a13cd5b2cc