### PR TITLE
feat: restart selection cycle after last user

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -289,6 +289,16 @@ describe('Funções Utilitárias', () => {
       expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
     });
 
+    it('deve reiniciar ciclo ao selecionar último usuário elegível', async () => {
+      const dados = JSON.parse(JSON.stringify(mockData));
+      dados.remaining = [{ name: 'User1', id: '1' }];
+
+      const resultado = await selectUser(dados);
+
+      expect(resultado.id).toBe('1');
+      expect(dados.remaining.length).toBe(mockData.all.length);
+    });
+
     it('deve reinserir usuários elegíveis quando todos restantes estão pulados', async () => {
       const dados = JSON.parse(JSON.stringify(mockData));
       dados.remaining = [{ name: 'User1', id: '1' }];

--- a/src/users.ts
+++ b/src/users.ts
@@ -76,9 +76,14 @@ export async function selectUser(data: UserData): Promise<UserEntry> {
     eligible = [...allEligible];
   }
 
+  const isLastEligible = eligible.length === 1;
+
   const index = Math.floor(Math.random() * eligible.length);
   const selected = eligible[index];
   data.remaining = data.remaining.filter(u => u.id !== selected.id);
+  if (isLastEligible) {
+    data.remaining = [...data.all];
+  }
   data.lastSelected = selected;
   data.lastSelectionDate = todayISO();
   await saveUsers(data);


### PR DESCRIPTION
## Summary
- restart selection cycle automatically when last eligible user is selected
- add unit test ensuring cycle resets after final selection

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689a2f44f0088325835b371bf1f7fe15