### PR TITLE
Refactor reminder intent handling

### DIFF
--- a/src/reminders.ts
+++ b/src/reminders.ts
@@ -4,83 +4,69 @@ import { i18n } from '@/i18n';
 
 const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
-interface ParsedReminder {
-  datetime: string;
-  text: string;
+interface ChatResult {
+  reply: string;
+  intent?: {
+    setReminder?: {
+      date: string;
+    };
+  };
 }
 
-async function detectReminderIntent(content: string): Promise<boolean> {
-  const prompt =
-    'Does the following message ask to set a reminder? The user may speak Portuguese. Respond in JSON with property "isReminder" as true or false. Message: ' +
-    JSON.stringify(content);
-  try {
-    const res = await ai.models.generateContent({
-      model: 'gemini-2.0-flash-001',
-      contents: prompt
-    });
-    const data = JSON.parse(res.text || '');
-    return Boolean(data?.isReminder);
-  } catch {
-    return false;
-  }
-}
-
-export async function parseReminder(
-  content: string
-): Promise<ParsedReminder | null> {
-  const prompt =
-    'Extract a future ISO 8601 datetime and the reminder text from the following reminder request. The user may speak Portuguese. ' +
-    'Respond in JSON with properties "datetime" and "text". Message: ' +
-    JSON.stringify(content);
-
-  try {
-    const response = await ai.models.generateContent({
-      model: 'gemini-2.0-flash-001',
-      contents: prompt
-    });
-    const text = response.text || '';
-    const data = JSON.parse(text);
-    if (data?.datetime) {
-      return { datetime: data.datetime, text: data.text || content };
-    }
-  } catch {
-    // ignore parsing errors
-  }
-  return null;
-}
-
-async function chatResponse(content: string): Promise<string> {
+async function chatResponse(content: string): Promise<ChatResult | null> {
   const lang = i18n.getLanguage() === 'pt-br' ? 'Portuguese' : 'English';
+  const schema = {
+    type: 'object',
+    properties: {
+      reply: { type: 'string' },
+      intent: {
+        type: 'object',
+        properties: {
+          setReminder: {
+            type: 'object',
+            properties: { date: { type: 'string' } },
+            required: ['date'],
+            additionalProperties: false
+          }
+        },
+        additionalProperties: false
+      }
+    },
+    required: ['reply'],
+    additionalProperties: false
+  } as const;
   const prompt =
-    `You are a friendly reminder bot. Reply conversationally in ${lang} to the following message: ` +
+    `The user may speak ${lang}. The "reply" value should be in ${lang}. Message: ` +
     JSON.stringify(content);
   try {
     const res = await ai.models.generateContent({
       model: 'gemini-2.0-flash-001',
-      contents: prompt
+      contents: prompt,
+      config: {
+        responseMimeType: 'application/json',
+        responseSchema: schema
+      }
     });
-    return res.text || i18n.t('reminder.defaultReply');
+    return JSON.parse(res.text || '') as ChatResult;
   } catch {
-    return i18n.t('reminder.defaultReply');
+    return null;
   }
 }
 
 export async function handleReminderMessage(message: Message): Promise<void> {
-  const isReminder = await detectReminderIntent(message.content);
-  if (!isReminder) {
-    const replyText = await chatResponse(message.content);
-    await message.reply(replyText);
+  const result = await chatResponse(message.content);
+  if (!result) {
+    await message.reply(i18n.t('reminder.parseError'));
     return;
   }
 
-  const parsed = await parseReminder(message.content);
-  if (!parsed) {
-    await message.reply(
-      i18n.t('reminder.parseError')
-    );
+  const dateStr = result.intent?.setReminder?.date;
+  if (!dateStr) {
+    await message.reply(result.reply || i18n.t('reminder.defaultReply'));
     return;
   }
-  const date = new Date(parsed.datetime);
+
+  const date = new Date(dateStr);
   const delay = date.getTime() - Date.now();
   if (isNaN(date.getTime()) || delay <= 0) {
     await message.reply(i18n.t('reminder.invalidTime'));
@@ -88,12 +74,14 @@ export async function handleReminderMessage(message: Message): Promise<void> {
   }
   setTimeout(() => {
     Promise.resolve(
-      message.author.send(i18n.t('reminder.notify', { text: parsed.text }))
+      message.author.send(
+        i18n.t('reminder.notify', { text: message.content })
+      )
     ).catch(() => {
       /* ignore */
     });
   }, delay);
-  await message.reply(i18n.t('reminder.set', { date: date.toISOString() }));
+  await message.reply(result.reply || i18n.t('reminder.set', { date: date.toISOString() }));
 }
 
 export function setupReminderListener(client: Client): void {


### PR DESCRIPTION
## Summary
- use Gemini response schema to get reminder intents in structured JSON
- adjust reminder tests to mock response schema call and verify config

## Testing
- `npm run lint`
- `npm test`
- `npm run build-zip`
- `unzip -l bot.zip`
- `NODE_ENV=test node build/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68acba9f33ac8325a8fd6142062a0a53