### PR TITLE
Fix last selected user persistence

### DIFF
--- a/src/__tests__/supabase.test.ts
+++ b/src/__tests__/supabase.test.ts
@@ -72,17 +72,19 @@ describe('Supabase saveUsers', () => {
     const data: UserData = {
       all: [{ id: '1', name: 'Alice' }],
       remaining: [{ id: '1', name: 'Alice' }],
-      lastSelected: { id: '1', name: 'Alice' },
       lastSelectionDate: '2024-01-01'
     };
 
     await database.saveUsers(data);
 
     const configQueries = getConfigQueries(fromMock);
-    const deleteQuery = configQueries[configQueries.length - 1].value;
+    const [upsertQuery, deleteQuery] = configQueries.map((query) => query.value);
 
+    expect(upsertQuery.upsert).toHaveBeenCalledWith([
+      { key: 'lastSelectionDate', value: '2024-01-01' }
+    ]);
     expect(deleteQuery.delete).toHaveBeenCalled();
     const deleteResult = deleteQuery.delete.mock.results[0].value;
-    expect(deleteResult.in).toHaveBeenCalledWith('key', ['retryUsers']);
+    expect(deleteResult.in).toHaveBeenCalledWith('key', ['retryUsers', 'lastSelected']);
   });
 });

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -292,7 +292,7 @@ class SupabaseDatabase {
       const { data: configs } = await this.client
         .from('config')
         .select('*')
-        .in('key', ['lastSelected', 'lastSelectionDate', 'retryUsers']);
+        .in('key', ['lastSelectionDate', 'retryUsers']);
 
       const userEntries: UserEntry[] = users.map((user: any) => ({
         id: user.id,
@@ -317,21 +317,20 @@ class SupabaseDatabase {
         skips: skipMap
       };
 
+      const lastSelectedUser = users.find((user: any) => user.last_selected);
+      if (lastSelectedUser) {
+        result.lastSelected = {
+          id: lastSelectedUser.id,
+          name: lastSelectedUser.name
+        };
+      }
+
       // Processar configurações
       if (configs) {
         const configMap: Record<string, string> = {};
         configs.forEach((cfg: any) => {
           configMap[cfg.key] = cfg.value;
         });
-
-        // Adicionar último selecionado se existir
-        if (configMap.lastSelected) {
-          const lastSelected = userEntries.find(u => u.id === configMap.lastSelected);
-          if (lastSelected) {
-            result.lastSelected = lastSelected;
-          }
-        }
-
         // Adicionar data da última seleção se existir
         if (configMap.lastSelectionDate) {
           result.lastSelectionDate = configMap.lastSelectionDate;
@@ -408,14 +407,7 @@ class SupabaseDatabase {
 
       // Salvar configurações
       const configsToSave = [] as { key: string; value: string }[];
-      const managedConfigKeys = ['lastSelected', 'lastSelectionDate', 'retryUsers'];
-      
-      if (data.lastSelected) {
-        configsToSave.push({
-          key: 'lastSelected',
-          value: data.lastSelected.id
-        });
-      }
+      const managedConfigKeys = ['lastSelectionDate', 'retryUsers', 'lastSelected'];
       
       if (data.lastSelectionDate) {
         configsToSave.push({


### PR DESCRIPTION
## Summary
- load the last selected user directly from the `users.last_selected` flag instead of relying on config entries
- stop persisting the `lastSelected` config key while still cleaning it up alongside other managed entries
- adjust Supabase persistence tests to reflect the new config handling expectations

## Testing
- npm run lint
- npm test
- npm run build-zip
- unzip -l bot.zip
- NODE_ENV=test node build/index.js *(fails: missing SUPABASE_URL/SUPABASE_ANON_KEY in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ed9386588325ac325fa14c9ddb06)